### PR TITLE
Do less work with displaying items

### DIFF
--- a/eco-util/src/main/java/com/willfp/eco/util/display/Display.java
+++ b/eco-util/src/main/java/com/willfp/eco/util/display/Display.java
@@ -55,6 +55,10 @@ public class Display {
      * @return The itemstack.
      */
     public ItemStack display(@NotNull final ItemStack itemStack) {
+        if (!itemStack.hasItemMeta()) {
+            return itemStack; // return early if there's no customization of the item
+        }
+
         Map<String, Object[]> pluginVarArgs = new HashMap<>();
 
         for (DisplayPriority priority : DisplayPriority.values()) {
@@ -65,10 +69,6 @@ public class Display {
         }
 
         revert(itemStack);
-
-        if (!itemStack.hasItemMeta()) {
-            return itemStack;
-        }
 
         ItemMeta meta = itemStack.getItemMeta();
 
@@ -124,15 +124,10 @@ public class Display {
 
         List<String> lore = meta.getLore();
 
-        if (lore == null) {
-            lore = new ArrayList<>();
+        if (lore != null && lore.removeIf(line -> line.startsWith(Display.PREFIX))) { // only apply lore modification if needed
+            meta.setLore(lore);
+            itemStack.setItemMeta(meta);
         }
-
-        lore.removeIf(line -> line.startsWith(Display.PREFIX));
-
-        meta.setLore(lore);
-
-        itemStack.setItemMeta(meta);
 
         for (DisplayPriority priority : DisplayPriority.values()) {
             List<DisplayModule> modules = MODULES.get(priority);


### PR DESCRIPTION
1. First check is because EnchantDisplay in EcoEnchants always calls getItemMeta, which forces Bukkit to create a meta object even for items that don't have any meta.
2. The check for lore is due to not needing to reset the lore (and thus have bukkit parse it again) if the lore didn't change.

I think another optimization could be reusing the same ItemMeta instance, because every time it gets set it has to convert the data back into NMS format. Then every time it gets created, it has to reparse the data from NMS format.

Overall the constant modification of items in every window update/set slot packet is pretty heavy, I wonder if there's a better way to do it.