### PR TITLE
Make defensive copy of CustomItem's returned item

### DIFF
--- a/eco-api/src/main/java/com/willfp/eco/core/items/CustomItem.java
+++ b/eco-api/src/main/java/com/willfp/eco/core/items/CustomItem.java
@@ -66,7 +66,7 @@ public class CustomItem implements TestableItem {
 
     @Override
     public ItemStack getItem() {
-        return item;
+        return item.clone();
     }
 
     /**


### PR DESCRIPTION
Without this change, external code is free to modify the underlying `ItemStack` within `CustomItem`.

This caused an issue for us when using [EcoItems' give command](https://github.com/Auxilor/EcoItems/blob/c76a9d2ebfa1435ae156b90656646aeb8795930a/eco-core/core-plugin/src/main/java/com/willfp/ecoitems/commands/CommandGive.java#L87-L108). Since the command calls `setAmount`, the `CustomItem` instance's `ItemStack` was being modified, which then caused issues such as custom crafting recipes outputting more items than expected.

A basic way to replicate this would be:

1. Add a custom, craftable item in EcoItems 
2. Give the item via `/ecoitems give <username> <item> 50`
3. When crafting the item, the crafted quantity is 50 too, which is obviously incorrect.