### PR TITLE
Fix getCustomItem loop eco items everytime it was called

### DIFF
--- a/eco-api/src/main/java/com/willfp/eco/core/items/Items.java
+++ b/eco-api/src/main/java/com/willfp/eco/core/items/Items.java
@@ -1,7 +1,5 @@
 package com.willfp.eco.core.items;
 
-import com.google.common.collect.HashBasedTable;
-import com.google.common.collect.Table;
 import com.willfp.eco.core.fast.FastItemStack;
 import com.willfp.eco.core.items.args.LookupArgParser;
 import com.willfp.eco.core.items.provider.ItemProvider;
@@ -12,7 +10,6 @@ import com.willfp.eco.core.recipe.parts.TestableStack;
 import com.willfp.eco.util.NamespacedKeyUtils;
 import com.willfp.eco.util.NumberUtils;
 import com.willfp.eco.util.StringUtils;
-import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.ItemStack;


### PR DESCRIPTION
This would store null items as empty optionals.
This would mean the cache would know which item hash looped the registry it won't do it again unless the cache is cleared.
Please NOTE this would still generate lag for new items added in the cache system but only the first time (until the cache is cleared and the process restarts).