### PR TITLE
Added ajParkour to softdepend

### DIFF
--- a/eco-core/core-plugin/src/main/resources/plugin.yml
+++ b/eco-core/core-plugin/src/main/resources/plugin.yml
@@ -46,3 +46,4 @@ softdepend:
   - EconomyShopGUI
   - zShop
   - DeluxeSellwands
+  - ajParkour


### PR DESCRIPTION
Should fix: `[15:17:52 WARN]: [eco] Loaded class org.slf4j.impl.StaticLoggerBinder from ajParkour v2.12.10 which is not a depend or softdepend of this plugin.`