### PR TITLE
Add an exception for armorstand in interact flag of WG

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/integrations/antigrief/AntigriefWorldGuard.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/integrations/antigrief/AntigriefWorldGuard.kt
@@ -11,10 +11,7 @@ import com.willfp.eco.core.integrations.antigrief.AntigriefIntegration
 import org.apache.commons.lang.Validate
 import org.bukkit.Location
 import org.bukkit.block.Block
-import org.bukkit.entity.Animals
-import org.bukkit.entity.LivingEntity
-import org.bukkit.entity.Monster
-import org.bukkit.entity.Player
+import org.bukkit.entity.*
 
 class AntigriefWorldGuard : AntigriefIntegration {
     override fun canBreakBlock(
@@ -85,6 +82,7 @@ class AntigriefWorldGuard : AntigriefIntegration {
             is Player -> Flags.PVP
             is Monster -> Flags.MOB_DAMAGE
             is Animals -> Flags.DAMAGE_ANIMALS
+            is ArmorStand -> Flags.INTERACT
             else -> return true
         }
 


### PR DESCRIPTION
It will be useful for battletraining plugin (https://www.spigotmc.org/resources/%E2%9A%94-battletraining-%E2%9A%94-trainingdummy-1-8-1-16.83945/) to deal full damage with EcoEnchants on armorstand in WG region of Spawn.