### PR TITLE
Display inconsistency fix

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/display/PacketHeldWindowItems.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/display/PacketHeldWindowItems.kt
@@ -10,7 +10,7 @@ import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
 
 class PacketHeldWindowItems(plugin: EcoPlugin) :
-    AbstractPacketAdapter(plugin, PacketType.Play.Server.WINDOW_ITEMS, false) {
+    AbstractPacketAdapter(plugin, PacketType.Play.Server.HELD_ITEM_SLOT, false) {
     override fun onSend(
         packet: PacketContainer,
         player: Player,

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/display/PacketWindowItems.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/display/PacketWindowItems.kt
@@ -28,9 +28,17 @@ class PacketWindowItems(plugin: EcoPlugin) : AbstractPacketAdapter(plugin, Packe
 
         val windowId = packet.integers.read(0)
 
-        if (windowId != 0) {
+        /*When things are working well, windowId is non-zero
+        * but occasionally this onsend method is called
+        * more than once with the additional calls having
+        * a windowId of 0. Those additional calls didn't
+        * allow the DisplayFrame to be set to empty and
+        * caused the display to break for tiers and enchants
+        * -Bradarr */
+
+        //if (windowId != 0) {
             player.lastDisplayFrame = DisplayFrame.EMPTY
-        }
+        //}
 
         val itemStacks = packet.itemListModifier.read(0) ?: return
 


### PR DESCRIPTION
@WillFP 
Finally found source of display bug that causes enchants to not appear and armor tiers to display as %tier%. Usually the PacketWindowItems onSend is called once per event, but sometimes it's called an additional 3 times with the windowId set to 0. This infrequent case caused the display to break because `player.lastDisplayFrame` was not set to empty during those additional calls. I also fixed a packet type that I think you intended to use in PacketHeldWindowItems.

I've tested this on 1.19.2 with displayframes set to true, and it works without any issues that I can see. Small bug XD

This should resolve Auxilor/EcoEnchants#299 and resolve Auxilor/EcoEnchants#303

Let me know if you want me to get any more debug info