### PR TITLE
Update of Lands api to the latest version (6.26.7).

### DIFF
--- a/eco-core/core-plugin/build.gradle
+++ b/eco-core/core-plugin/build.gradle
@@ -31,7 +31,8 @@ dependencies {
     compileOnly('com.github.TownyAdvanced:Towny:0.97.2.6') {
         exclude group: 'com.zaxxer', module: 'HikariCP'
     }
-    compileOnly 'com.github.angeschossen:LandsAPI:5.15.2'
+    compileOnly 'com.github.angeschossen:LandsAPI:6.26.7'
+    compileOnly 'com.github.angeschossen:PluginFrameworkAPI:1.0.0'
     compileOnly 'fr.neatmonster:nocheatplus:3.16.1-SNAPSHOT'
     compileOnly 'com.github.jiangdashao:matrix-api-repo:317d4635fd'
     compileOnly 'com.gmail.nossr50.mcMMO:mcMMO:2.1.202'

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/integrations/antigrief/AntigriefLands.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/integrations/antigrief/AntigriefLands.kt
@@ -12,7 +12,7 @@ import org.bukkit.entity.Monster
 import org.bukkit.entity.Player
 
 class AntigriefLands(private val plugin: EcoPlugin) : AntigriefIntegration {
-    private val landsIntegration = LandsIntegration.of(this.plugin);
+    private val landsIntegration = LandsIntegration.of(this.plugin)
     override fun canBreakBlock(
         player: Player,
         block: Block

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/integrations/antigrief/AntigriefLands.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/integrations/antigrief/AntigriefLands.kt
@@ -2,8 +2,8 @@ package com.willfp.eco.internal.spigot.integrations.antigrief
 
 import com.willfp.eco.core.EcoPlugin
 import com.willfp.eco.core.integrations.antigrief.AntigriefIntegration
+import me.angeschossen.lands.api.LandsIntegration
 import me.angeschossen.lands.api.flags.Flags
-import me.angeschossen.lands.api.integration.LandsIntegration
 import org.bukkit.Location
 import org.bukkit.block.Block
 import org.bukkit.entity.Animals
@@ -12,12 +12,12 @@ import org.bukkit.entity.Monster
 import org.bukkit.entity.Player
 
 class AntigriefLands(private val plugin: EcoPlugin) : AntigriefIntegration {
-    private val landsIntegration = LandsIntegration(this.plugin)
+    private val landsIntegration = LandsIntegration.of(this.plugin);
     override fun canBreakBlock(
         player: Player,
         block: Block
     ): Boolean {
-        val area = landsIntegration.getAreaByLoc(block.location) ?: return true
+        val area = landsIntegration.getArea(block.location) ?: return true
         return area.hasFlag(player, Flags.BLOCK_BREAK, false)
     }
 
@@ -25,7 +25,7 @@ class AntigriefLands(private val plugin: EcoPlugin) : AntigriefIntegration {
         player: Player,
         location: Location
     ): Boolean {
-        val area = landsIntegration.getAreaByLoc(location) ?: return true
+        val area = landsIntegration.getArea(location) ?: return true
         return area.hasFlag(player, Flags.ATTACK_PLAYER, false) && area.hasFlag(player, Flags.ATTACK_ANIMAL, false)
     }
 
@@ -33,7 +33,7 @@ class AntigriefLands(private val plugin: EcoPlugin) : AntigriefIntegration {
         player: Player,
         block: Block
     ): Boolean {
-        val area = landsIntegration.getAreaByLoc(block.location) ?: return true
+        val area = landsIntegration.getArea(block.location) ?: return true
         return area.hasFlag(player, Flags.BLOCK_PLACE, false)
     }
 
@@ -42,7 +42,7 @@ class AntigriefLands(private val plugin: EcoPlugin) : AntigriefIntegration {
         victim: LivingEntity
     ): Boolean {
 
-        val area = landsIntegration.getAreaByLoc(victim.location) ?: return true
+        val area = landsIntegration.getArea(victim.location) ?: return true
 
         return when(victim) {
             is Player -> area.hasFlag(player, Flags.ATTACK_PLAYER, false)
@@ -53,7 +53,7 @@ class AntigriefLands(private val plugin: EcoPlugin) : AntigriefIntegration {
     }
 
     override fun canPickupItem(player: Player, location: Location): Boolean {
-        val area = landsIntegration.getAreaByLoc(location) ?: return true
+        val area = landsIntegration.getArea(location) ?: return true
         return area.hasFlag(player, Flags.ITEM_PICKUP, false)
     }
 


### PR DESCRIPTION
The latest version of Lands changes its API in depth, which caused an error spam when checking anti-grief because the API methods were not recognized anymore.

```
[11:46:42] [Server thread/ERROR]: [31m[Minecraft] Could not pass event BlockDropItemEvent to EcoEnchants v9.12.1[0m
java.lang.NoSuchFieldError: BLOCK_BREAK
	at com.willfp.eco.internal.spigot.integrations.antigrief.AntigriefLands.canBreakBlock(AntigriefLands.kt:21) ~[eco-6.47.0-all.jar:?]
	at com.willfp.eco.core.integrations.antigrief.AntigriefManager.lambda$canBreakBlock$3(AntigriefManager.java:62) ~[eco-6.47.0-all.jar:?]
	at java.util.stream.MatchOps$1MatchSink.accept(MatchOps.java:90) ~[?:?]
	at java.util.HashMap$KeySpliterator.tryAdvance(HashMap.java:1728) ~[?:?]
	at java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:129) ~[?:?]
	at java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:527) ~[?:?]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:513) ~[?:?]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[?:?]
	at java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:230) ~[?:?]
	at java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:196) ~[?:?]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
	at java.util.stream.ReferencePipeline.allMatch(ReferencePipeline.java:637) ~[?:?]
	at com.willfp.eco.core.integrations.antigrief.AntigriefManager.canBreakBlock(AntigriefManager.java:62) ~[eco-6.47.0-all.jar:?]
	at com.willfp.ecoenchants.enchants.impl.EnchantmentTelekinesis$TelekinesisHandler.handle(EnchantmentTelekinesis.kt:44) ~[EcoEnchants v9.12.1.jar:?]
	at com.destroystokyo.paper.event.executor.MethodHandleEventExecutor.execute(MethodHandleEventExecutor.java:40) ~[pufferfish-api-1.19.2-R0.1-SNAPSHOT.jar:?]
	at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:76) ~[pufferfish-api-1.19.2-R0.1-SNAPSHOT.jar:git-Pufferfish-47]
	at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[pufferfish-api-1.19.2-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:672) ~[pufferfish-api-1.19.2-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.craftbukkit.v1_19_R1.event.CraftEventFactory.handleBlockDropItemEvent(CraftEventFactory.java:409) ~[pufferfish-1.19.2.jar:git-Pufferfish-47]
	at net.minecraft.server.level.ServerPlayerGameMode.destroyBlock(ServerPlayerGameMode.java:442) ~[?:?]
	at net.minecraft.server.level.ServerPlayerGameMode.destroyAndAck(ServerPlayerGameMode.java:328) ~[?:?]
	at net.minecraft.server.level.ServerPlayerGameMode.handleBlockBreakAction(ServerPlayerGameMode.java:266) ~[?:?]
	at net.minecraft.server.network.ServerGamePacketListenerImpl.handlePlayerAction(ServerGamePacketListenerImpl.java:1884) ~[?:?]
	at net.minecraft.network.protocol.game.ServerboundPlayerActionPacket.handle(ServerboundPlayerActionPacket.java:42) ~[?:?]
	at net.minecraft.network.protocol.game.ServerboundPlayerActionPacket.a(ServerboundPlayerActionPacket.java:15) ~[?:?]
	at net.minecraft.network.protocol.PacketUtils.lambda$ensureRunningOnSameThread$1(PacketUtils.java:51) ~[?:?]
	at net.minecraft.server.TickTask.run(TickTask.java:18) ~[pufferfish-1.19.2.jar:git-Pufferfish-47]
	at net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:153) ~[?:?]
	at net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:24) ~[?:?]
	at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:1343) ~[pufferfish-1.19.2.jar:git-Pufferfish-47]
	at net.minecraft.server.MinecraftServer.d(MinecraftServer.java:185) ~[pufferfish-1.19.2.jar:git-Pufferfish-47]
	at net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:126) ~[?:?]
	at net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:1320) ~[pufferfish-1.19.2.jar:git-Pufferfish-47]
	at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:1313) ~[pufferfish-1.19.2.jar:git-Pufferfish-47]
	at net.minecraft.util.thread.BlockableEventLoop.runAllTasks(BlockableEventLoop.java:114) ~[?:?]
	at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1447) ~[pufferfish-1.19.2.jar:git-Pufferfish-47]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1175) ~[pufferfish-1.19.2.jar:git-Pufferfish-47]
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:307) ~[pufferfish-1.19.2.jar:git-Pufferfish-47]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
```