### PR TITLE
Fix Prices evaluation if they include player placeholders

### DIFF
--- a/eco-api/src/main/java/com/willfp/eco/core/price/Prices.java
+++ b/eco-api/src/main/java/com/willfp/eco/core/price/Prices.java
@@ -71,10 +71,6 @@ public final class Prices {
                 ctx
         );
 
-        if (function.apply(context) <= 0) {
-            return new PriceFree();
-        }
-
         // Default to economy
         if (priceName == null) {
             return new PriceEconomy(context, function);


### PR DESCRIPTION
This 3 lines are basically killing ability to use any kind of player placeholder without additional constants:

Example:

1) Let's have price with value `%ecojobs_miner%` (number >=0)
 - Price creator will evaulate this with config's MathContext as `0`
 - That means that result Price will be `new PriceFree();`
 
 2) Let's have price with value `%ecojobs_miner% + 1` (number >=1)
 - Price creator will evaulate this with config's MathContext as `1`
 - That means that result Price will be actually dependent on player's placeholder
 
 I found this when I was trying to create this price `100 * %ecojobs_miner%`, which is also resolved as `0`, as many other possible expressions...