### PR TITLE
Use existing isPlayerPlaced value to track who placed a block

### DIFF
--- a/eco-api/src/main/java/com/willfp/eco/util/BlockUtils.java
+++ b/eco-api/src/main/java/com/willfp/eco/util/BlockUtils.java
@@ -3,6 +3,7 @@ package com.willfp.eco.util;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
@@ -96,6 +97,34 @@ public final class BlockUtils {
                 NamespacedKeyUtils.createEcoKey(Integer.toString(block.getLocation().hashCode(), 16)),
                 PersistentDataType.INTEGER
         );
+    }
+    /**
+     * Get who placed the block (as an internal ID).
+     *
+     * @param block The block.
+     * @return Internal ID of placing player, or 0 if not placed by a player.
+     */
+    public static int placedByID(@NotNull final Block block) {
+        Chunk chunk = block.getChunk();
+
+        return chunk.getPersistentDataContainer().getOrDefault(
+            NamespacedKeyUtils.createEcoKey(Integer.toString(block.getLocation().hashCode(), 16)),
+            PersistentDataType.INTEGER,
+            0
+        );
+    }
+
+    /**
+     * Get whether a specific player placed the block.
+     *
+     * @param block The block.
+     * @param player The player to check.
+     * @return If placed by that specific player.
+     */
+    public static boolean isPlacedBy(@NotNull final Block block, @NotNull final OfflinePlayer player) {
+        int placed_by = placedByID(block);
+        int local_id = PlayerUtils.getLocalID(player);
+        return placed_by == local_id;        
     }
 
     private BlockUtils() {

--- a/eco-api/src/main/java/com/willfp/eco/util/PlayerUtils.java
+++ b/eco-api/src/main/java/com/willfp/eco/util/PlayerUtils.java
@@ -33,6 +33,16 @@ public final class PlayerUtils {
             PersistentDataKeyType.STRING,
             "Unknown Player"
     );
+    /**
+     * The data key for saved player local IDs.
+     * The default value of 1 means no local ID has been assigned; this is to allow the
+     * gradual migration of BlockUtils isPlayerPlaced values.
+     */
+    private static final PersistentDataKey<Integer> PLAYER_LOCAL_ID = new PersistentDataKey<>(
+            NamespacedKeyUtils.createEcoKey("player_local_id"),
+            PersistentDataKeyType.INT,
+            1
+    );
 
     /**
      * Get the audience from a player.
@@ -104,6 +114,29 @@ public final class PlayerUtils {
         }
 
         return saved;
+    }
+
+    /**
+     * Get local ID for a player.  
+     * Local IDs are more compact than UUIDs, but are local to our storage backing. 
+     * They're useful in scenarios where we want to store a player identifier per-block,
+     * like in BlockUtils.isPlacedBy
+     * 
+     * @param player The player.
+     * @return The player local ID.
+     */
+    public static Integer getLocalID(@NotNull final OfflinePlayer player) {
+        PlayerProfile profile = PlayerProfile.load(player);
+        Integer local_id = profile.read(PLAYER_LOCAL_ID);
+
+        // If we haven't gotten a player local ID, generate one here.
+        if (local_id.equals(PLAYER_LOCAL_ID.getDefaultValue())) {
+            Integer generatedID = ServerUtils.generateLocalID();
+            profile.write(PLAYER_LOCAL_ID, generatedID);
+            return generatedID;
+        }
+
+        return local_id;
     }
 
     /**

--- a/eco-api/src/main/java/com/willfp/eco/util/ServerUtils.java
+++ b/eco-api/src/main/java/com/willfp/eco/util/ServerUtils.java
@@ -1,11 +1,24 @@
 package com.willfp.eco.util;
 
 import com.willfp.eco.core.Eco;
+import com.willfp.eco.core.data.ServerProfile;
+import com.willfp.eco.core.data.keys.PersistentDataKey;
+import com.willfp.eco.core.data.keys.PersistentDataKeyType;
 
 /**
  * Utilities / API methods for the server.
  */
 public final class ServerUtils {
+    /**
+     * The data key on the server profile which holds the top player local id.
+     * The default value is 1 to allow gradual migration of BlockUtils isPlayerPlaced values.
+     */
+    private static final PersistentDataKey<Integer> TOP_LOCAL_ID = new PersistentDataKey<>(
+            NamespacedKeyUtils.createEcoKey("top_player_local_id"),
+            PersistentDataKeyType.INT,
+            1
+    );
+
     /**
      * Get the current server TPS.
      *
@@ -19,6 +32,21 @@ public final class ServerUtils {
         } else {
             return tps;
         }
+    }
+
+    
+    /**
+     * Generates a local ID for a player by incrementing the top value.
+     * Local IDs are more compact than UUIDs, but are local to our storage backing. 
+     * 
+     * @return The player local ID.
+     */
+    public static Integer generateLocalID() {
+        ServerProfile profile = ServerProfile.load();
+        Integer local_id = profile.read(TOP_LOCAL_ID);
+        local_id += 1;
+        profile.write(TOP_LOCAL_ID, local_id);
+        return local_id;
     }
 
     private ServerUtils() {

--- a/eco-api/src/main/kotlin/com/willfp/eco/util/BlockUtils.kt
+++ b/eco-api/src/main/kotlin/com/willfp/eco/util/BlockUtils.kt
@@ -3,7 +3,12 @@
 package com.willfp.eco.util
 
 import org.bukkit.block.Block
+import org.bukkit.OfflinePlayer;
 
 /** @see ArrowUtils.getBow */
 val Block.isPlayerPlaced: Boolean
     get() = BlockUtils.isPlayerPlaced(this)
+
+/** @see BlockUtils.IsPlacedBy */
+fun Block.isPlacedBy(player: OfflinePlayer) =
+    BlockUtils.isPlacedBy(this,player)

--- a/eco-api/src/main/kotlin/com/willfp/eco/util/PlayerUtils.kt
+++ b/eco-api/src/main/kotlin/com/willfp/eco/util/PlayerUtils.kt
@@ -12,6 +12,10 @@ import org.bukkit.entity.Player
 val OfflinePlayer.savedDisplayName: String
     get() = PlayerUtils.getSavedDisplayName(this)
 
+/** @see PlayerUtils.getLocalID */
+val OfflinePlayer.localID: Int
+    get() = PlayerUtils.getLocalID(this)
+
 /** @see PlayerUtils.getAudience */
 fun Player.asAudience(): Audience =
     PlayerUtils.getAudience(this)


### PR DESCRIPTION
### What is this?
This is a proof-of-concept of using the isPlayerPlaced value to store an identifier for the player who placed the block. 

The existing behavior is to set that value to "1" if placed by a player... and then do nothing with the actual integer stored.

Since we're already storing four bytes per player-placed block, why not use them? 

### Why make this change?
This change allows for the easy creation of a self_placed filter, which I'll include in a PR to the libreforge repo shortly. 

What good is a self_placed filter?

-  A skill that levels up when breaking other player's stuff, but not your own.
- Weapons that deal bonus damage when standing on home turf.
- Tools that mine your own blocks instantly.
- Explosives that don't damage your own blocks
- More ideas as they come to me.

### How it works

This change assigns each player a local ID, and then uses that ID instead of the value "1" for the isPlayerPlaced value.

Local ID is a single INT stored stored on the PlayerProfile. Storing it on the player profile makes it a proxy value for UUID. 

### Why not use UUID instead of a local ID?

If additional memory use isn't a concern, UUIDs are the most robust solution. However, using a UUID here would increase storage space used by isPlayerPlaced 4x. 

Doing it with local IDs, as this PR does, allows us to use the existing value and thus has no increase in per-block storage use. 

Given the size of a signed 4-byte integer, a server won't run out of local IDs until Minecraft sells 2 billion copies and all of those copies come to play on a specific server. 

### Why not rely on the anti-grief integration?

The anti-grief integration only tracks who has permission to modify a given block. Not who placed it in the first place. Even if we were to modify the integration, not every anti-grief plugin implements a "who placed this block" function. 

And again, we already store a value here. This is just making use of it.

### Performance Analysis
The existing behavior is to write to the chunk's profile each time a player places a block. This behavior is unchanged.

There is now an additional read from the player's profile when placing blocks, to determine the player's local ID. Depending on how that read occurs in the code (I haven't read deeply yet, but I'm assuming it's memoized somewhere so it's not hitting the DB/Disk every read) this should have negligable impact.

### Backwards Compatibility
This change doesn't break any existing behavior.

Before this PR, worlds with blocks marked by isPlayerPlaced use the value 1 to denote their placement, and no value if they were not player placed. I've ensured that the local player IDs start at 2, so that there's no conflict on migrating versions.

There's also no conflict if the server downgrades from this version; the actual value set by isPlayerPlaced is ignored prior to this PR.