### PR TITLE
Fix data desync issues

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/data/EcoProfile.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/data/EcoProfile.kt
@@ -16,9 +16,7 @@ abstract class EcoProfile(
     override fun <T : Any> write(key: PersistentDataKey<T>, value: T) {
         this.data[key] = value
 
-        val changedKeys = CHANGE_MAP[uuid] ?: mutableSetOf()
-        changedKeys.add(key)
-        CHANGE_MAP[uuid] = changedKeys
+        CHANGE_MAP.add(uuid)
     }
 
     override fun <T : Any> read(key: PersistentDataKey<T>): T {
@@ -44,7 +42,7 @@ abstract class EcoProfile(
     }
 
     companion object {
-        val CHANGE_MAP: MutableMap<UUID, MutableSet<PersistentDataKey<*>>> = ConcurrentHashMap()
+        val CHANGE_MAP: MutableSet<UUID> = ConcurrentHashMap.newKeySet()
     }
 }
 

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/data/ProfileHandler.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/data/ProfileHandler.kt
@@ -22,7 +22,7 @@ class ProfileHandler(
     private val type: HandlerType,
     private val plugin: EcoSpigotPlugin
 ) {
-    private val loaded = mutableMapOf<UUID, Profile>()
+    val loaded = mutableMapOf<UUID, Profile>()
 
     val handler: DataHandler = when (type) {
         HandlerType.YAML -> YamlDataHandler(plugin, this)

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/data/storage/ProfileSaver.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/data/storage/ProfileSaver.kt
@@ -12,10 +12,20 @@ class ProfileSaver(
         val interval = plugin.configYml.getInt("save-interval").toLong()
 
         plugin.scheduler.runTimer(20, interval) {
-            for ((uuid, set) in EcoProfile.CHANGE_MAP) {
-                handler.saveKeysFor(uuid, set)
+            val iterator = EcoProfile.CHANGE_MAP.iterator()
+
+            while (iterator.hasNext()) {
+                val uuid = iterator.next()
+                iterator.remove()
+
+                val profile = handler.loaded[uuid] ?: continue
+
+                if (profile !is EcoProfile) {
+                    continue
+                }
+
+                handler.saveKeysFor(uuid, profile.data.keys)
             }
-            EcoProfile.CHANGE_MAP.clear()
         }
     }
 }


### PR DESCRIPTION
For some reason previous code causes data to not be saved.

Also there is a issue when player disconnect from the server and his data will not be saved, due to unloading his profile in quit event, so his changed data will disappear, and then ProfileSaver will try to save new data, but his profile is null, so it will loaded from database without any changes.

After this commit, if player disconnects and his profile had any changes it will not be saved, so you need to make sure to save  player data when player leaves.

Fixes: #244 #208 and maybe #118 