### PR TITLE
Fix IllegalArgumentException

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/integrations/hologram/HologramDecentHolograms.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/integrations/hologram/HologramDecentHolograms.kt
@@ -27,7 +27,10 @@ class HologramDecentHolograms : HologramIntegration {
         }
 
         override fun setContents(contents: List<String>) {
-            DHAPI.setHologramLines(DHAPI.getHologram(id), contents)
+            val hologram = DHAPI.getHologram(id)
+            if (hologram != null) {
+                DHAPI.setHologramLines(hologram, contents)
+            }
         }
     }
 }


### PR DESCRIPTION
Added null check to `setContents`, which exists for `remove` method.

Stacktrace of fixed exception:
```
[EcoCrates] Task #462 for EcoCrates v1.13.10 generated an exception
java.lang.IllegalArgumentException: The validated object is null
        at org.apache.commons.lang.Validate.notNull(Validate.java:192) ~[commons-lang-2.6.jar:2.6]
        at org.apache.commons.lang.Validate.notNull(Validate.java:178) ~[commons-lang-2.6.jar:2.6]
        at eu.decentsoftware.holograms.api.DHAPI.setHologramLines(DHAPI.java:841) ~[DecentHolograms-2.8.6 (1).jar:?]
        at eu.decentsoftware.holograms.api.DHAPI.setHologramLines(DHAPI.java:827) ~[DecentHolograms-2.8.6 (1).jar:?]
        at com.willfp.eco.internal.spigot.integrations.hologram.HologramDecentHolograms$HologramImplDecentHolograms.setContents(HologramDecentHolograms.kt:30) ~[eco-6.69.2-all.jar:?]
        at com.willfp.ecocrates.crate.placed.PlacedCrate.tickHolograms(PlacedCrate.kt:64) ~[EcoCrates v1.13.10.jar:?]
        at com.willfp.ecocrates.crate.placed.PlacedCrate.tick$core_plugin(PlacedCrate.kt:35) ~[EcoCrates v1.13.10.jar:?]
        at com.willfp.ecocrates.crate.placed.CrateDisplay.tick(CrateDisplay.kt:17) ~[EcoCrates v1.13.10.jar:?]
        at com.willfp.ecocrates.crate.placed.CrateDisplay.start$lambda$0(CrateDisplay.kt:11) ~[EcoCrates v1.13.10.jar:?]
        at org.bukkit.craftbukkit.v1_20_R2.scheduler.CraftTask.run(CraftTask.java:101) ~[purpur-1.20.2.jar:git-Purpur-2095]
        at org.bukkit.craftbukkit.v1_20_R2.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:480) ~[purpur-1.20.2.jar:git-Purpur-2095]
        at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1497) ~[purpur-1.20.2.jar:git-Purpur-2095]
        at net.minecraft.server.dedicated.DedicatedServer.tickChildren(DedicatedServer.java:486) ~[purpur-1.20.2.jar:git-Purpur-2095]
        at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1406) ~[purpur-1.20.2.jar:git-Purpur-2095]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1177) ~[purpur-1.20.2.jar:git-Purpur-2095]
        at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:320) ~[purpur-1.20.2.jar:git-Purpur-2095]
        at java.lang.Thread.run(Thread.java:1589) ~[?:?]
```
