### PR TITLE
Update ParticleFactoryRGB.kt

### DIFF
--- a/eco-core/core-backend/src/main/kotlin/com/willfp/eco/internal/particle/ParticleFactoryRGB.kt
+++ b/eco-core/core-backend/src/main/kotlin/com/willfp/eco/internal/particle/ParticleFactoryRGB.kt
@@ -12,7 +12,7 @@ object ParticleFactoryRGB : ParticleFactory {
         if (Prerequisite.HAS_1_20_5.isMet) {
             Particle.valueOf("DUST")
         } else {
-            Particle.valueOf("REDSTONE_DUST")
+            Particle.valueOf("REDSTONE")
         }
     }.getOrNull()
 


### PR DESCRIPTION
Fixed a silly mistake that stopped RGB particles working in any eco since 6.71.1