### PR TITLE
Only create teams for colors

### DIFF
--- a/eco-api/src/main/java/com/willfp/eco/util/TeamUtils.java
+++ b/eco-api/src/main/java/com/willfp/eco/util/TeamUtils.java
@@ -54,6 +54,9 @@ public final class TeamUtils {
 
     static {
         for (ChatColor value : ChatColor.values()) {
+            if (!value.isColor()) {
+                continue;
+            }
             fromChatColor(value);
         }
     }


### PR DESCRIPTION
TeamUtils creates teams for all formatting codes, not just color codes, which causes a crash on new Minecraft versions when saving, because new versions are stricter and validate this.

```
java.lang.IllegalStateException: Formatting was not a valid color: §m; Formatting was not a valid color: §n; Formatting was not a valid color: §o; Formatting was not a valid color: §k; Formatting was not a valid color: §l
	at com.mojang.serialization.DataResult$Error.getOrThrow(DataResult.java:287)
	at com.mojang.serialization.DataResult.getOrThrow(DataResult.java:81)
	at net.minecraft.world.level.storage.DimensionDataStorage.encodeUnchecked(DimensionDataStorage.java:197)
	at net.minecraft.world.level.storage.DimensionDataStorage.lambda$collectDirtyTagsToSave$8(DimensionDataStorage.java:188)
	at java.base/java.util.Optional.ifPresent(Optional.java:178)
	at net.minecraft.world.level.storage.DimensionDataStorage.lambda$collectDirtyTagsToSave$9(DimensionDataStorage.java:187)
	at java.base/java.util.HashMap.forEach(HashMap.java:1429)
	at net.minecraft.world.level.storage.DimensionDataStorage.collectDirtyTagsToSave(DimensionDataStorage.java:187)
	at net.minecraft.world.level.storage.DimensionDataStorage.scheduleSave(DimensionDataStorage.java:147)
	at net.minecraft.server.level.ServerLevel.saveLevelData(ServerLevel.java:1413)
	at net.minecraft.server.level.ServerLevel.saveIncrementally(ServerLevel.java:1349)
	at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1552)
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1252)
	at net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:310)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```

 This PR updates TeamUtils to skip formatting codes that aren't color codes.