### PR TITLE
Fix method call to CraftRegistry.Java in NewEcoFastItemStack

### DIFF
--- a/eco-core/core-nms/modern/src/main/kotlin/com/willfp/eco/internal/spigot/proxy/common/modern/NewEcoFastItemStack.kt
+++ b/eco-core/core-nms/modern/src/main/kotlin/com/willfp/eco/internal/spigot/proxy/common/modern/NewEcoFastItemStack.kt
@@ -76,8 +76,7 @@ open class NewEcoFastItemStack(
         enchantment: Enchantment,
         checkStored: Boolean
     ): Int {
-        val minecraft = CraftRegistry.bukkitToMinecraftHolder<Enchantment,
-        Registries.ENCHANTMENT>(
+        val minecraft = CraftRegistry.bukkitToMinecraftHolder<Enchantment, Registries.ENCHANTMENT>(
             enchantment
         )
 


### PR DESCRIPTION
Fixes incorrectly passed parameters and argument in function getEnchantmentLevel()

from CraftRegistry.java:
`public static <B extends Keyed, M> Holder<M> bukkitToMinecraftHolder(final B bukkit)`

addresses https://github.com/Auxilor/eco/issues/404 and https://github.com/Auxilor/eco/pull/391