### PR TITLE
Added back Nexo to loadbefore to fix compatibility issue

### DIFF
--- a/eco-core/core-plugin/src/main/resources/plugin.yml
+++ b/eco-core/core-plugin/src/main/resources/plugin.yml
@@ -17,6 +17,7 @@ loadbefore:
   - DeluxeCombat
   - ShopGUIPlus
   - DeluxeMenus
+  - Nexo
 softdepend:
   - ItemBridge
   - HuskClaims


### PR DESCRIPTION
After testing Nexo 1.11 and the last version of Eco I realized there was issue of linkage popping in the console, mana of EcoSkills not regenerating and I realized Nexo was removed from loadbefore and found the commit that mentioned that you didn't know if it was necessary. I can confirm you it is was caused the issue because I added it back and everything is back to normal. I hope you merge that soon. Thanks.