### PR TITLE
Fix old placeholders not removing from registry

### DIFF
--- a/eco-api/src/main/java/com/willfp/eco/core/integrations/placeholder/PlaceholderManager.java
+++ b/eco-api/src/main/java/com/willfp/eco/core/integrations/placeholder/PlaceholderManager.java
@@ -98,7 +98,7 @@ public final class PlaceholderManager {
         // Storing as immutable set leads to slower times to register placeholders, but much
         // faster times to access registrations.
         Set<Placeholder> pluginPlaceholders = new HashSet<>(REGISTERED_PLACEHOLDERS.get(placeholder.getPlugin()));
-        pluginPlaceholders.removeIf(p -> p.getPattern().equals(placeholder.getPattern()));
+        pluginPlaceholders.removeIf(p -> p.getPattern().pattern().equals(placeholder.getPattern().pattern()));
         pluginPlaceholders.add(placeholder);
         REGISTERED_PLACEHOLDERS.put(placeholder.getPlugin(), ImmutableSet.copyOf(pluginPlaceholders));
     }


### PR DESCRIPTION
`Pattern.equals()` compares the references to the objects, i.e. uses the == operator. This is not good, because a new Pattern is created for the new placeholder, so the above mentioned method throws `false` even tho it's the same pattern.
https://stackoverflow.com/a/10055112
This fixes the issue with reloading libreforge's custom conditional placeholders that did not work correctly.