### PR TITLE
Update LibsDisguises repository and dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -86,7 +86,7 @@ allprojects {
         maven("https://redempt.dev")
 
         // LibsDisguises
-        maven("https://repo.md-5.net/content/groups/public/")
+        maven("https://mvn.lib.co.nz/public")
 
         // PlayerPoints
         maven("https://repo.rosewooddev.io/repository/public/")

--- a/eco-core/core-plugin/build.gradle.kts
+++ b/eco-core/core-plugin/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
         exclude(group = "com.google.code.gson", module = "gson")
     }
     implementation("com.willfp:ModelEngineBridge:1.2.0")
+    implementation(group = "me.libraryaddict.disguises", name = "libsdisguises", version = "11.0.13")
 
     // Included in spigot jar
     compileOnly("com.google.code.gson:gson:2.8.8")
@@ -57,7 +58,6 @@ dependencies {
     compileOnly("com.github.sirblobman.api:core:2.9-SNAPSHOT")
     compileOnly("com.github.sirblobman.combatlogx:api:11.4-SNAPSHOT")
     compileOnly("com.SirBlobman.combatlogx:CombatLogX-API:10.0.0.0-SNAPSHOT")
-    compileOnly("LibsDisguises:LibsDisguises:10.0.26")
     compileOnly("com.denizenscript:denizen:1.2.7-SNAPSHOT") {
         exclude(group = "*", module = "*")
     }


### PR DESCRIPTION
Changed the LibsDisguises Maven repository URL and updated the dependency declaration in core-plugin. Removed the old compileOnly dependency and added an implementation dependency with the correct group and version.