### PR TITLE
Fix inverted logic in notifyOfflinePlayerRequired()

### DIFF
--- a/eco-api/src/main/java/com/willfp/eco/core/command/CommandBase.java
+++ b/eco-api/src/main/java/com/willfp/eco/core/command/CommandBase.java
@@ -252,7 +252,7 @@ public interface CommandBase {
 
         boolean hasPlayedBefore = player.hasPlayedBefore() || player.isOnline();
 
-        notifyFalse(!hasPlayedBefore, key);
+        notifyFalse(hasPlayedBefore, key);
 
         return player;
     }


### PR DESCRIPTION
## Summary
- `notifyFalse(!hasPlayedBefore, key)` threw the error notification when `hasPlayedBefore` was true -- the exact opposite of the intended behavior
- Commands using `notifyOfflinePlayerRequired()` would reject known players and accept unknown ones
- Removed the erroneous `!` negation

## Test plan
- [ ] Verify commands that use `notifyOfflinePlayerRequired()` correctly accept players who have played before
- [ ] Verify commands correctly reject player names that have never joined the server