### PR TITLE
Fix PriceItem.pay() removing more items than required

### DIFF
--- a/eco-api/src/main/java/com/willfp/eco/core/price/impl/PriceItem.java
+++ b/eco-api/src/main/java/com/willfp/eco/core/price/impl/PriceItem.java
@@ -123,12 +123,11 @@ public final class PriceItem implements Price {
 
             if (item.matches(itemStack)) {
                 int itemAmount = itemStack.getAmount();
+                int remaining = toRemove - count;
 
-                if (itemAmount > toRemove) {
-                    itemStack.setAmount(itemAmount - toRemove);
-                }
-
-                if (itemAmount <= toRemove) {
+                if (itemAmount > remaining) {
+                    itemStack.setAmount(itemAmount - remaining);
+                } else {
                     itemStack.setAmount(0);
                     itemStack.setType(Material.AIR);
                 }


### PR DESCRIPTION
## Summary
- `PriceItem.pay()` compared each stack's amount against the total `toRemove` instead of the remaining amount needed
- When items spanned multiple inventory slots, players lost more items than the actual price
- Now tracks remaining items needed and only removes the correct amount from each stack

## Test plan
- [ ] Verify that paying with items spread across multiple stacks removes exactly the correct total
- [ ] Verify partial stack removal works correctly (e.g., removing 3 from a stack of 8 leaves 5)
- [ ] Verify single-stack payments still work correctly