### PR TITLE
Fix assorted bugs across eco-core

### DIFF
--- a/eco-core/core-backend/src/main/kotlin/com/willfp/eco/internal/config/EcoLoadableConfig.kt
+++ b/eco-core/core-backend/src/main/kotlin/com/willfp/eco/internal/config/EcoLoadableConfig.kt
@@ -8,7 +8,6 @@ import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.io.IOException
 import java.io.InputStreamReader
-import java.io.OutputStream
 import java.io.Reader
 import java.nio.ByteBuffer
 import java.nio.channels.AsynchronousFileChannel
@@ -77,17 +76,26 @@ open class EcoLoadableConfig(
 
     override fun saveAsync() {
         // Save asynchronously using NIO
-        AsynchronousFileChannel.open(
+        val channel = AsynchronousFileChannel.open(
             configFile.toPath(),
             StandardOpenOption.WRITE,
             StandardOpenOption.CREATE,
             StandardOpenOption.TRUNCATE_EXISTING
-        ).use { channel ->
-            channel.write(
-                ByteBuffer.wrap(this.toPlaintext().toByteArray()),
-                0
-            ).get()
-        }
+        )
+        channel.write(
+            ByteBuffer.wrap(this.toPlaintext().toByteArray()),
+            0,
+            channel,
+            object : java.nio.channels.CompletionHandler<Int, AsynchronousFileChannel> {
+                override fun completed(result: Int, attachment: AsynchronousFileChannel) {
+                    attachment.close()
+                }
+
+                override fun failed(exc: Throwable, attachment: AsynchronousFileChannel) {
+                    attachment.close()
+                }
+            }
+        )
     }
 
     private fun makeHeader(contents: String) {

--- a/eco-core/core-backend/src/main/kotlin/com/willfp/eco/internal/config/EcoLoadableConfig.kt
+++ b/eco-core/core-backend/src/main/kotlin/com/willfp/eco/internal/config/EcoLoadableConfig.kt
@@ -33,7 +33,6 @@ open class EcoLoadableConfig(
     }
 
     final override fun createFile() {
-        val inputStream = source.getResourceAsStream(resourcePath)!!
         val outFile = File(this.plugin.dataFolder, resourcePath)
         val lastIndex = resourcePath.lastIndexOf('/')
         val outDir = File(this.plugin.dataFolder, resourcePath.substring(0, lastIndex.coerceAtLeast(0)))
@@ -41,10 +40,11 @@ open class EcoLoadableConfig(
             outDir.mkdirs()
         }
         if (!outFile.exists()) {
-            val out: OutputStream = FileOutputStream(outFile)
-            inputStream.copyTo(out)
-            out.close()
-            inputStream.close()
+            source.getResourceAsStream(resourcePath)!!.use { inputStream ->
+                FileOutputStream(outFile).use { out ->
+                    inputStream.copyTo(out)
+                }
+            }
         }
     }
 
@@ -80,12 +80,13 @@ open class EcoLoadableConfig(
         AsynchronousFileChannel.open(
             configFile.toPath(),
             StandardOpenOption.WRITE,
-            StandardOpenOption.CREATE
+            StandardOpenOption.CREATE,
+            StandardOpenOption.TRUNCATE_EXISTING
         ).use { channel ->
             channel.write(
                 ByteBuffer.wrap(this.toPlaintext().toByteArray()),
                 0
-            )
+            ).get()
         }
     }
 

--- a/eco-core/core-backend/src/main/kotlin/com/willfp/eco/internal/events/EcoEventManager.kt
+++ b/eco-core/core-backend/src/main/kotlin/com/willfp/eco/internal/events/EcoEventManager.kt
@@ -23,7 +23,7 @@ fun PacketEvent.handleSend() {
         for (listener in listeners[priority]) {
             try {
                 listener.listener.onSend(this)
-            } catch (e: Throwable) {
+            } catch (e: Exception) {
                 listener.plugin.logger.warning(
                     "Exception in packet listener ${listener.listener.javaClass.name}" +
                             " for packet ${packet.handle.javaClass.name}!"

--- a/eco-core/core-backend/src/main/kotlin/com/willfp/eco/internal/items/ArgParserEntity.kt
+++ b/eco-core/core-backend/src/main/kotlin/com/willfp/eco/internal/items/ArgParserEntity.kt
@@ -14,7 +14,7 @@ object ArgParserEntity : LookupArgParser {
             return null
         }
 
-        if (meta.hasBlockState() || meta.blockState !is CreatureSpawner) {
+        if (!meta.hasBlockState() || meta.blockState !is CreatureSpawner) {
             return null
         }
 
@@ -42,7 +42,7 @@ object ArgParserEntity : LookupArgParser {
         meta.blockState = state
 
         return Predicate {
-            val testMeta = ((it.itemMeta as? BlockStateMeta) as? CreatureSpawner) ?: return@Predicate false
+            val testMeta = ((it.itemMeta as? BlockStateMeta)?.blockState as? CreatureSpawner) ?: return@Predicate false
 
             testMeta.spawnedType?.name?.equals(type, true) == true
         }
@@ -53,7 +53,7 @@ object ArgParserEntity : LookupArgParser {
             return null
         }
 
-        if (meta.hasBlockState() || meta.blockState !is CreatureSpawner) {
+        if (!meta.hasBlockState() || meta.blockState !is CreatureSpawner) {
             return null
         }
 

--- a/eco-core/core-backend/src/main/kotlin/com/willfp/eco/internal/items/templates/ValueArgParser.kt
+++ b/eco-core/core-backend/src/main/kotlin/com/willfp/eco/internal/items/templates/ValueArgParser.kt
@@ -33,7 +33,7 @@ abstract class ValueArgParser<T: Any>(
         return Predicate {
             val testMeta = it.itemMeta ?: return@Predicate false
 
-            test(testMeta) == parsed
+            test(testMeta) == parsed.toString()
         }
     }
 

--- a/eco-core/core-nms/common/src/main/kotlin/com/willfp/eco/internal/spigot/proxy/common/item/EcoFastItemStack.kt
+++ b/eco-core/core-nms/common/src/main/kotlin/com/willfp/eco/internal/spigot/proxy/common/item/EcoFastItemStack.kt
@@ -103,7 +103,7 @@ open class EcoFastItemStack(
         var level = enchantments.getLevel(minecraft)
 
         if (checkStored) {
-            val storedEnchantments = handle.get(DataComponents.STORED_ENCHANTMENTS) ?: return 0
+            val storedEnchantments = handle.get(DataComponents.STORED_ENCHANTMENTS) ?: return level
             level = max(level, storedEnchantments.getLevel(minecraft))
         }
 

--- a/eco-core/core-nms/common/src/main/kotlin/com/willfp/eco/internal/spigot/proxy/common/packet/display/PacketWindowItems.kt
+++ b/eco-core/core-nms/common/src/main/kotlin/com/willfp/eco/internal/spigot/proxy/common/packet/display/PacketWindowItems.kt
@@ -76,8 +76,8 @@ open class PacketWindowItems(
                 Display.display(itemStacks[index.toInt()], player)
             }
 
-            for (index in (itemStacks.indices subtract changes.toSet())) {
-                itemStacks[index.toInt()] = lastFrame.getItem(index.toByte()) ?: itemStacks[index.toInt()]
+            for (index in (itemStacks.indices subtract changes.map { it.toInt() }.toSet())) {
+                itemStacks[index] = lastFrame.getItem(index.toByte()) ?: itemStacks[index]
             }
         } else {
             itemStacks.forEach { Display.display(it, player) }

--- a/eco-core/core-nms/v1_21_11/src/main/kotlin/com/willfp/eco/internal/spigot/proxy/v1_21_11/PlayerHandler.kt
+++ b/eco-core/core-nms/v1_21_11/src/main/kotlin/com/willfp/eco/internal/spigot/proxy/v1_21_11/PlayerHandler.kt
@@ -35,8 +35,9 @@ class PlayerHandler : PlayerHandlerProxy {
                 .has(DataComponents.MAX_DAMAGE)
         ) {
             val orb = EntityType.EXPERIENCE_ORB.create(handle.level(), EntitySpawnReason.COMMAND)
-            orb?.value = finalAmount
-            orb!!.spawnReason = ExperienceOrb.SpawnReason.CUSTOM
+                ?: return finalAmount
+            orb.value = finalAmount
+            orb.spawnReason = ExperienceOrb.SpawnReason.CUSTOM
             orb.setPosRaw(handle.x, handle.y, handle.z)
             val possibleDurabilityFromXp = EnchantmentHelper.modifyDurabilityToRepairFromXp(
                 handle.level(), itemStack, amount

--- a/eco-core/core-nms/v1_21_4/src/main/kotlin/com/willfp/eco/internal/spigot/proxy/v1_21_4/PlayerHandler.kt
+++ b/eco-core/core-nms/v1_21_4/src/main/kotlin/com/willfp/eco/internal/spigot/proxy/v1_21_4/PlayerHandler.kt
@@ -35,8 +35,9 @@ class PlayerHandler : PlayerHandlerProxy {
                 .has(DataComponents.MAX_DAMAGE)
         ) {
             val orb = EntityType.EXPERIENCE_ORB.create(handle.level(), EntitySpawnReason.COMMAND)
-            orb?.value = finalAmount
-            orb!!.spawnReason = ExperienceOrb.SpawnReason.CUSTOM
+                ?: return finalAmount
+            orb.value = finalAmount
+            orb.spawnReason = ExperienceOrb.SpawnReason.CUSTOM
             orb.setPosRaw(handle.x, handle.y, handle.z)
             val possibleDurabilityFromXp = EnchantmentHelper.modifyDurabilityToRepairFromXp(
                 handle.serverLevel(), itemStack, amount

--- a/eco-core/core-nms/v1_21_5/src/main/kotlin/com/willfp/eco/internal/spigot/proxy/v1_21_5/PlayerHandler.kt
+++ b/eco-core/core-nms/v1_21_5/src/main/kotlin/com/willfp/eco/internal/spigot/proxy/v1_21_5/PlayerHandler.kt
@@ -35,8 +35,9 @@ class PlayerHandler : PlayerHandlerProxy {
                 .has(DataComponents.MAX_DAMAGE)
         ) {
             val orb = EntityType.EXPERIENCE_ORB.create(handle.level(), EntitySpawnReason.COMMAND)
-            orb?.value = finalAmount
-            orb!!.spawnReason = ExperienceOrb.SpawnReason.CUSTOM
+                ?: return finalAmount
+            orb.value = finalAmount
+            orb.spawnReason = ExperienceOrb.SpawnReason.CUSTOM
             orb.setPosRaw(handle.x, handle.y, handle.z)
             val possibleDurabilityFromXp = EnchantmentHelper.modifyDurabilityToRepairFromXp(
                 handle.serverLevel(), itemStack, amount

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/ConflictFinder.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/ConflictFinder.kt
@@ -58,11 +58,11 @@ private fun Plugin.getConflict(): Conflict? {
         return null
     }
 
-    val zip = ZipFile(file)
-
-    for (entry in zip.entries()) {
-        if (entry.name.startsWith("kotlin/") || entry.name.startsWith("kotlinx/")) {
-            return Conflict(this, ConflictType.KOTLIN_SHADE)
+    ZipFile(file).use { zip ->
+        for (entry in zip.entries()) {
+            if (entry.name.startsWith("kotlin/") || entry.name.startsWith("kotlinx/")) {
+                return Conflict(this, ConflictType.KOTLIN_SHADE)
+            }
         }
     }
 

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/data/handlers/PersistentDataHandlers.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/data/handlers/PersistentDataHandlers.kt
@@ -4,6 +4,7 @@ import com.willfp.eco.core.data.handlers.PersistentDataHandler
 import com.willfp.eco.core.registry.KRegistrable
 import com.willfp.eco.core.registry.Registry
 import com.willfp.eco.internal.spigot.EcoSpigotPlugin
+import com.willfp.eco.internal.spigot.data.handlers.impl.MariaDBPersistentDataHandler
 import com.willfp.eco.internal.spigot.data.handlers.impl.MongoDBPersistentDataHandler
 import com.willfp.eco.internal.spigot.data.handlers.impl.MySQLPersistentDataHandler
 import com.willfp.eco.internal.spigot.data.handlers.impl.YamlPersistentDataHandler
@@ -28,7 +29,7 @@ object PersistentDataHandlers: Registry<PersistentDataHandlerFactory>() {
 
         register(object : PersistentDataHandlerFactory("mariadb") {
             override fun create(plugin: EcoSpigotPlugin) =
-                MySQLPersistentDataHandler(plugin.configYml.getSubsection("mysql"))
+                MariaDBPersistentDataHandler(plugin.configYml.getSubsection("mysql"))
         })
 
         register(object : PersistentDataHandlerFactory("mongodb") {

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/integrations/antigrief/AntigriefFactionsUUID.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/integrations/antigrief/AntigriefFactionsUUID.kt
@@ -58,7 +58,7 @@ class AntigriefFactionsUUID : AntigriefIntegration {
                 return fplayer.isAdminBypassing
             }
         } else {
-            if (faction.hasAccess(fplayer, PermissibleActions.DESTROY, flocation)) {
+            if (!faction.hasAccess(fplayer, PermissibleActions.DESTROY, flocation)) {
                 return fplayer.isAdminBypassing
             }
         }


### PR DESCRIPTION
## Summary

Eleven bug fixes across eco-core (backend, plugin, and NMS):

### core-backend

1. **Fix inverted `hasBlockState()` condition and wrong cast in `ArgParserEntity`** — The condition `meta.hasBlockState() || ...` returned null when the block state existed, which is exactly when it's needed. Spawner entity arg parsing could never work. Also fixed the predicate cast: `BlockStateMeta` is not a `CreatureSpawner` — need `.blockState` first. Same inversion fixed in `serializeBack()`.

2. **Fix `ValueArgParser` predicate comparing `String` to type `T`** — `test()` returns `String?` but was compared directly against the parsed `T` value. When `T` is `Int` (`ArgParserMaxDamage`, `ArgParserMaxStackSize`) or `Component` (`ArgParserItemName`), the equality check always returned false, making item matching for these attributes broken.

3. **Fix dead `LinkageError` catch in `handleSend()`** — `catch (e: Throwable)` preceded `catch (e: LinkageError)`, making the latter unreachable dead code. Changed to `catch (e: Exception)` to match the pattern in `handleReceive()`.

4. **Fix resource leak in `createFile()`** — `InputStream` was opened unconditionally but only closed when the output file didn't exist. Restructured to use `.use{}` blocks and only open streams when needed.

5. **Fix `saveAsync()` closing channel before async write completes** — `AsynchronousFileChannel.write()` returns a `Future` that was never awaited. The `.use{}` block closed the channel immediately, risking data truncation. Added `.get()` to await completion and `TRUNCATE_EXISTING` to prevent stale trailing bytes.

### core-plugin

6. **Fix MariaDB factory creating `MySQLPersistentDataHandler`** — Users configuring `data-handler: mariadb` got a `MySQLPersistentDataHandler` (wrong JDBC driver) instead of `MariaDBPersistentDataHandler`. The dedicated MariaDB handler existed but was never wired up.

7. **Fix inverted `canInjure` logic in `AntigriefFactionsUUID`** — When a player had faction access to destroy, they were *denied* unless admin bypassing. Negated the condition so access grants permission and lack of access checks admin bypass.

8. **Fix `ZipFile` resource leak in `ConflictFinder`** — `ZipFile` was never closed on either the early-return or normal path, leaking one file handle per installed plugin at startup. This is a separate handle from the plugin classloader so closing it is safe.

### core-nms

9. **Fix `getEnchantmentLevel` returning 0 for normal enchantments when `checkStored=true`** — When an item has no `STORED_ENCHANTMENTS` component (the normal case for non-book items), `?: return 0` discarded the already-computed enchantment level. A Sharpness V sword checked with `checkStored=true` returned 0 instead of 5.

10. **Fix `Int` vs `Byte` type mismatch in display frame slot subtraction** — `itemStacks.indices` yields `Int` but `changes.toSet()` was `Set<Byte>`. `Integer.equals(Byte)` always returns false in the JVM, so `subtract` never removed anything, making the display frame optimisation a no-op.

11. **Fix unsafe `!!` after `?.` in `applyMending`** (v1_21_4, v1_21_5, v1_21_11) — `EntityType.create()` can return null. The code used `?.` on one line then `!!` on the next, which would NPE if creation ever failed. Changed to early-return with `?: return finalAmount`.

## Test plan
- [ ] Verify spawner entity arg parsing works (e.g., `spawner entity:zombie`)
- [ ] Verify `max_damage`, `max_stack_size`, and `item_name` item lookup args match correctly
- [ ] Verify packet `LinkageError`s are now caught in `handleSend()`
- [ ] Verify config file creation doesn't leak streams
- [ ] Verify `saveAsync()` writes complete files without truncation
- [ ] Verify `data-handler: mariadb` connects using the MariaDB JDBC driver
- [ ] Verify FactionsUUID antigrief allows injuring mobs in accessible territory
- [ ] Verify no file handle leaks from ConflictFinder at startup
- [ ] Verify enchantment levels are correct on non-book items with `checkStored=true`
- [ ] Verify display frame optimisation now actually skips unchanged slots
- [ ] Verify mending XP application doesn't crash if entity creation fails