### PR TITLE
Fix Banners not being able to be applied to Ecoitem-Shields

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/recipes/listeners/ComplexInVanilla.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/recipes/listeners/ComplexInVanilla.kt
@@ -5,6 +5,7 @@ import com.willfp.eco.core.items.Items
 import com.willfp.eco.internal.spigot.recipes.CraftingRecipeListener
 import com.willfp.eco.internal.spigot.recipes.GenericCraftEvent
 import com.willfp.eco.internal.spigot.recipes.RecipeListener
+import org.bukkit.Material
 
 object ComplexInVanilla : RecipeListener {
     override fun handle(event: GenericCraftEvent) {
@@ -17,6 +18,9 @@ object ComplexInVanilla : RecipeListener {
         }
 
         for (itemStack in event.inventory.matrix) {
+            if (itemStack?.type == Material.SHIELD) {
+                continue
+            }
             if (Items.isCustomItem(itemStack)) {
                 event.deny()
             }


### PR DESCRIPTION
- This fixes that Banners can't be applied to Shields made from Ecoitems
- Don't know if its appropriate there, may also be a config option or should be added somewhere else, idk