### PR TITLE
fix: 26.1.1 compatibility.

### DIFF
--- a/eco-core/core-nms/v26_1_1/build.gradle.kts
+++ b/eco-core/core-nms/v26_1_1/build.gradle.kts
@@ -30,6 +30,15 @@ tasks {
         exclude("com/willfp/eco/internal/spigot/proxy/v1_21_8/SNBTConverter*.class")
         exclude("com/willfp/eco/internal/spigot/proxy/v1_21_8/packet/PacketContainerClick*.class")
 
+        // 26.1.1 changes that broke `common` :(
+        exclude("com/willfp/eco/internal/spigot/proxy/common/ai/entity/CatLieOnBedGoalFactory*.class")
+        exclude("com/willfp/eco/internal/spigot/proxy/common/ai/entity/CatSitOnBedGoalFactory*.class")
+        exclude("com/willfp/eco/internal/spigot/proxy/common/ai/entity/FollowBoatsGoalFactory*.class")
+        exclude("com/willfp/eco/internal/spigot/proxy/common/ai/entity/IllusionerBlindnessSpellGoalFactory*.class")
+        exclude("com/willfp/eco/internal/spigot/proxy/common/ai/entity/IllusionerMirrorSpellGoalFactory*.class")
+        exclude("com/willfp/eco/internal/spigot/proxy/common/ai/target/DefendVillageGoalFactory*.class")
+        exclude("com/willfp/eco/internal/spigot/proxy/common/recipes/RecipeManager*.class")
+
         duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     }
 

--- a/eco-core/core-nms/v26_1_1/src/main/kotlin/com/willfp/eco/internal/spigot/proxy/v26_1_1/common/ai/entity/CatLieOnBedGoalFactory.kt
+++ b/eco-core/core-nms/v26_1_1/src/main/kotlin/com/willfp/eco/internal/spigot/proxy/v26_1_1/common/ai/entity/CatLieOnBedGoalFactory.kt
@@ -1,0 +1,20 @@
+package com.willfp.eco.internal.spigot.proxy.v26_1_1.common.ai.entity
+
+import com.willfp.eco.core.entities.ai.entity.EntityGoalCatLieOnBed
+import com.willfp.eco.internal.spigot.proxy.common.ai.EntityGoalFactory
+import net.minecraft.world.entity.PathfinderMob
+import net.minecraft.world.entity.ai.goal.CatLieOnBedGoal
+import net.minecraft.world.entity.ai.goal.Goal
+import net.minecraft.world.entity.animal.feline.Cat
+
+object CatLieOnBedGoalFactory : EntityGoalFactory<EntityGoalCatLieOnBed> {
+    override fun create(apiGoal: EntityGoalCatLieOnBed, entity: PathfinderMob): Goal? {
+        return CatLieOnBedGoal(
+            entity as? Cat ?: return null,
+            apiGoal.speed,
+            apiGoal.range
+        )
+    }
+
+    override fun isGoalOfType(goal: Goal) = goal is CatLieOnBedGoal
+}

--- a/eco-core/core-nms/v26_1_1/src/main/kotlin/com/willfp/eco/internal/spigot/proxy/v26_1_1/common/ai/entity/CatSitOnBedGoalFactory.kt
+++ b/eco-core/core-nms/v26_1_1/src/main/kotlin/com/willfp/eco/internal/spigot/proxy/v26_1_1/common/ai/entity/CatSitOnBedGoalFactory.kt
@@ -1,0 +1,19 @@
+package com.willfp.eco.internal.spigot.proxy.v26_1_1.common.ai.entity
+
+import com.willfp.eco.core.entities.ai.entity.EntityGoalCatSitOnBed
+import com.willfp.eco.internal.spigot.proxy.common.ai.EntityGoalFactory
+import net.minecraft.world.entity.PathfinderMob
+import net.minecraft.world.entity.ai.goal.CatSitOnBlockGoal
+import net.minecraft.world.entity.ai.goal.Goal
+import net.minecraft.world.entity.animal.feline.Cat
+
+object CatSitOnBedGoalFactory : EntityGoalFactory<EntityGoalCatSitOnBed> {
+    override fun create(apiGoal: EntityGoalCatSitOnBed, entity: PathfinderMob): Goal? {
+        return CatSitOnBlockGoal(
+            entity as? Cat ?: return null,
+            apiGoal.speed
+        )
+    }
+
+    override fun isGoalOfType(goal: Goal) = goal is CatSitOnBlockGoal
+}

--- a/eco-core/core-nms/v26_1_1/src/main/kotlin/com/willfp/eco/internal/spigot/proxy/v26_1_1/common/ai/entity/FollowBoatsGoalFactory.kt
+++ b/eco-core/core-nms/v26_1_1/src/main/kotlin/com/willfp/eco/internal/spigot/proxy/v26_1_1/common/ai/entity/FollowBoatsGoalFactory.kt
@@ -1,0 +1,19 @@
+package com.willfp.eco.internal.spigot.proxy.v26_1_1.common.ai.entity
+
+import com.willfp.eco.core.entities.ai.entity.EntityGoalFollowBoats
+import com.willfp.eco.internal.spigot.proxy.common.ai.EntityGoalFactory
+import net.minecraft.world.entity.PathfinderMob
+import net.minecraft.world.entity.ai.goal.FollowPlayerRiddenEntityGoal
+import net.minecraft.world.entity.ai.goal.Goal
+import net.minecraft.world.entity.vehicle.boat.AbstractBoat
+
+object FollowBoatsGoalFactory : EntityGoalFactory<EntityGoalFollowBoats> {
+    override fun create(apiGoal: EntityGoalFollowBoats, entity: PathfinderMob): Goal {
+        return FollowPlayerRiddenEntityGoal(
+            entity,
+            AbstractBoat::class.java
+        )
+    }
+
+    override fun isGoalOfType(goal: Goal) = goal is FollowPlayerRiddenEntityGoal
+}

--- a/eco-core/core-nms/v26_1_1/src/main/kotlin/com/willfp/eco/internal/spigot/proxy/v26_1_1/common/ai/entity/IllusionerBlindnessSpellGoalFactory.kt
+++ b/eco-core/core-nms/v26_1_1/src/main/kotlin/com/willfp/eco/internal/spigot/proxy/v26_1_1/common/ai/entity/IllusionerBlindnessSpellGoalFactory.kt
@@ -1,0 +1,23 @@
+package com.willfp.eco.internal.spigot.proxy.v26_1_1.common.ai.entity
+
+import com.willfp.eco.core.entities.ai.entity.EntityGoalIllusionerBlindnessSpell
+import com.willfp.eco.internal.spigot.proxy.common.ai.EntityGoalFactory
+import net.minecraft.world.entity.PathfinderMob
+import net.minecraft.world.entity.ai.goal.Goal
+import net.minecraft.world.entity.monster.illager.Illusioner
+
+object IllusionerBlindnessSpellGoalFactory : EntityGoalFactory<EntityGoalIllusionerBlindnessSpell> {
+    override fun create(apiGoal: EntityGoalIllusionerBlindnessSpell, entity: PathfinderMob): Goal? {
+        if (entity !is Illusioner) return null
+
+        // Have to use reflection for it to work
+        return Illusioner::class.java.declaredClasses[1]
+            .getDeclaredConstructor(Illusioner::class.java)
+            .apply { isAccessible = true }
+            .newInstance(entity) as Goal
+    }
+
+    override fun isGoalOfType(goal: Goal): Boolean {
+        return Illusioner::class.java.declaredClasses[1].isInstance(goal)
+    }
+}

--- a/eco-core/core-nms/v26_1_1/src/main/kotlin/com/willfp/eco/internal/spigot/proxy/v26_1_1/common/ai/entity/IllusionerMirrorSpellGoalFactory.kt
+++ b/eco-core/core-nms/v26_1_1/src/main/kotlin/com/willfp/eco/internal/spigot/proxy/v26_1_1/common/ai/entity/IllusionerMirrorSpellGoalFactory.kt
@@ -1,0 +1,23 @@
+package com.willfp.eco.internal.spigot.proxy.v26_1_1.common.ai.entity
+
+import com.willfp.eco.core.entities.ai.entity.EntityGoalIllusionerMirrorSpell
+import com.willfp.eco.internal.spigot.proxy.common.ai.EntityGoalFactory
+import net.minecraft.world.entity.PathfinderMob
+import net.minecraft.world.entity.ai.goal.Goal
+import net.minecraft.world.entity.monster.illager.Illusioner
+
+object IllusionerMirrorSpellGoalFactory : EntityGoalFactory<EntityGoalIllusionerMirrorSpell> {
+    override fun create(apiGoal: EntityGoalIllusionerMirrorSpell, entity: PathfinderMob): Goal? {
+        if (entity !is Illusioner) return null
+
+        // Have to use reflection for it to work
+        return Illusioner::class.java.declaredClasses[0]
+            .getDeclaredConstructor(Illusioner::class.java)
+            .apply { isAccessible = true }
+            .newInstance(entity) as Goal
+    }
+
+    override fun isGoalOfType(goal: Goal): Boolean {
+        return Illusioner::class.java.declaredClasses[0].isInstance(goal)
+    }
+}

--- a/eco-core/core-nms/v26_1_1/src/main/kotlin/com/willfp/eco/internal/spigot/proxy/v26_1_1/common/ai/target/DefendVillageGoalFactory.kt
+++ b/eco-core/core-nms/v26_1_1/src/main/kotlin/com/willfp/eco/internal/spigot/proxy/v26_1_1/common/ai/target/DefendVillageGoalFactory.kt
@@ -1,0 +1,18 @@
+package com.willfp.eco.internal.spigot.proxy.v26_1_1.common.ai.target
+
+import com.willfp.eco.core.entities.ai.target.TargetGoalDefendVillage
+import com.willfp.eco.internal.spigot.proxy.common.ai.TargetGoalFactory
+import net.minecraft.world.entity.PathfinderMob
+import net.minecraft.world.entity.ai.goal.Goal
+import net.minecraft.world.entity.ai.goal.target.DefendVillageTargetGoal
+import net.minecraft.world.entity.animal.golem.IronGolem
+
+object DefendVillageGoalFactory : TargetGoalFactory<TargetGoalDefendVillage> {
+    override fun create(apiGoal: TargetGoalDefendVillage, entity: PathfinderMob): Goal? {
+        return DefendVillageTargetGoal(
+            entity as? IronGolem ?: return null
+        )
+    }
+
+    override fun isGoalOfType(goal: Goal) = goal is DefendVillageTargetGoal
+}

--- a/eco-core/core-nms/v26_1_1/src/main/kotlin/com/willfp/eco/internal/spigot/proxy/v26_1_1/common/recipes/RecipeManager.kt
+++ b/eco-core/core-nms/v26_1_1/src/main/kotlin/com/willfp/eco/internal/spigot/proxy/v26_1_1/common/recipes/RecipeManager.kt
@@ -1,0 +1,113 @@
+package com.willfp.eco.internal.spigot.proxy.v26_1_1.common.recipes
+
+import com.google.common.base.Function
+import com.google.common.collect.Maps
+import net.minecraft.core.registries.Registries
+import net.minecraft.server.MinecraftServer
+import net.minecraft.world.item.crafting.CraftingRecipe
+import net.minecraft.world.item.crafting.Ingredient
+import net.minecraft.world.item.crafting.Recipe
+import net.minecraft.world.item.crafting.RecipeHolder
+import net.minecraft.world.item.crafting.ShapedRecipe
+import net.minecraft.world.item.crafting.ShapedRecipePattern
+import net.minecraft.world.item.crafting.ShapelessRecipe
+import org.bukkit.Bukkit
+import org.bukkit.NamespacedKey
+import org.bukkit.craftbukkit.inventory.CraftItemStack
+import org.bukkit.craftbukkit.inventory.CraftRecipe
+import org.bukkit.craftbukkit.inventory.CraftShapedRecipe
+import org.bukkit.craftbukkit.inventory.CraftShapelessRecipe
+import org.bukkit.craftbukkit.util.CraftNamespacedKey
+import org.bukkit.inventory.Recipe as BukkitRecipe
+import org.bukkit.inventory.RecipeChoice as BukkitRecipeChoice
+import org.bukkit.inventory.ShapedRecipe as BukkitShapedRecipe
+import org.bukkit.inventory.ShapelessRecipe as BukkitShapelessRecipe
+import java.util.*
+
+object RecipeManager {
+
+    private fun getMinecraftRecipeManager() = MinecraftServer.getServer().resources.managers().recipeManager
+
+    fun removeRecipeNoResend(recipeKey: NamespacedKey): Boolean {
+        val recipeManager = getMinecraftRecipeManager()
+        val toRemove = Bukkit.getRecipe(recipeKey) ?: return false
+        val recipe = toRemove.toNMSEquivalent
+        recipeManager.recipes.removeRecipe(recipe.id)
+        return true
+    }
+
+    fun addRecipeNoResend(recipe: BukkitRecipe): Boolean {
+        val recipeManager = getMinecraftRecipeManager()
+        val toAdd: RecipeHolder<*> = recipe.toNMSEquivalent
+        recipeManager.recipes.addRecipe(toAdd)
+        return true
+    }
+
+    fun reloadRecipes() {
+        val recipeManager = getMinecraftRecipeManager()
+        recipeManager.finalizeRecipeLoading()
+    }
+
+    private fun replaceUndefinedIngredientsWithEmpty(
+        shape: Array<String>,
+        ingredients: MutableMap<Char, BukkitRecipeChoice?>
+    ): List<String> {
+        for (i in shape.indices) {
+            val row = shape[i]
+            val filteredRow = StringBuilder(row.length)
+            for (character in row.toCharArray()) {
+                filteredRow.append(if (ingredients[character] == null) ' ' else character)
+            }
+            shape[i] = filteredRow.toString()
+        }
+        return shape.toList()
+    }
+
+    private val BukkitRecipe.toNMSEquivalent: RecipeHolder<*>
+        get() {
+            when (this) {
+                is BukkitShapedRecipe -> {
+                    val craftRecipe = CraftShapedRecipe.fromBukkitRecipe(this)
+                    val ingredients: MutableMap<Char, BukkitRecipeChoice?> = craftRecipe.getChoiceMap().filterKeys { c: Char? -> c != null }.toMutableMap()
+                    val shape: List<String> = replaceUndefinedIngredientsWithEmpty(craftRecipe.shape, ingredients)
+                    ingredients.values.removeIf { obj: BukkitRecipeChoice? -> Objects.isNull(obj) }
+                    val recipeConverter: Function<BukkitRecipeChoice?, Ingredient> = Function { bukkit: BukkitRecipeChoice? ->
+                        CraftRecipe.toIngredient(bukkit, false)
+                    }
+                    val data: Map<Char, Ingredient> = Maps.transformValues(ingredients, recipeConverter)
+                    val pattern = ShapedRecipePattern.of(data, shape)
+                    val recipe = ShapedRecipe(
+                        Recipe.CommonInfo(true),
+                        CraftingRecipe.CraftingBookInfo(CraftRecipe.getCategory(this.category), this.group),
+                        pattern,
+                        CraftItemStack.asTemplate(this.result)
+                    )
+                    return RecipeHolder(
+                        CraftNamespacedKey.toResourceKey(Registries.RECIPE, this.key),
+                        recipe
+                    )
+                }
+                is BukkitShapelessRecipe -> {
+                    val craftRecipe = CraftShapelessRecipe.fromBukkitRecipe(this)
+                    val ingred: MutableList<BukkitRecipeChoice> = craftRecipe.getChoiceList()
+                    val data: MutableList<Ingredient> = ArrayList(ingred.size)
+                    for (i in ingred) {
+                        data.add(CraftRecipe.toIngredient(i, true))
+                    }
+                    val recipe = ShapelessRecipe(
+                        Recipe.CommonInfo(true),
+                        CraftingRecipe.CraftingBookInfo(CraftRecipe.getCategory(this.category), this.group),
+                        CraftItemStack.asTemplate(this.result),
+                        data
+                    )
+                    return RecipeHolder(
+                        CraftNamespacedKey.toResourceKey(Registries.RECIPE, this.key),
+                        recipe
+                    )
+                }
+                else -> {
+                    throw UnsupportedOperationException("Unsupported recipe type: " + this.javaClass.name)
+                }
+            }
+        }
+}


### PR DESCRIPTION
## Summary

### Goals Changes
`net.minecraft.world.entity.animal.Cat` -> `net.minecraft.world.entity.animal.feline.Cat`
`net.minecraft.world.entity.ai.goal.FollowBoatGoal` -> `net.minecraft.world.entity.ai.goal.FollowPlayerRiddenEntityGoal`
`net.minecraft.world.entity.monster.Illusioner` -> `import net.minecraft.world.entity.monster.illager.Illusioner`
`net.minecraft.world.entity.animal.IronGolem` -> `net.minecraft.world.entity.animal.golem.IronGolem`

### `RecipeManager` Changes
A bunch of changes to how Ingredients are created from Bukkit Ingredients, and also how NMS Shaped / Shapeless recipes.

