### PR TITLE
feat: Layers in Menus

### DIFF
--- a/eco-api/src/main/java/com/willfp/eco/core/gui/menu/MenuBuilder.java
+++ b/eco-api/src/main/java/com/willfp/eco/core/gui/menu/MenuBuilder.java
@@ -60,7 +60,7 @@ public interface MenuBuilder extends PageBuilder {
      * @return The builder.
      */
     @Override
-    MenuBuilder addComponent(@NotNull MenuLayer layer,
+    MenuBuilder addComponent(int layer,
                              int row,
                              int column,
                              @NotNull GUIComponent component);

--- a/eco-api/src/main/java/com/willfp/eco/core/gui/menu/MenuLayer.java
+++ b/eco-api/src/main/java/com/willfp/eco/core/gui/menu/MenuLayer.java
@@ -1,31 +1,23 @@
 package com.willfp.eco.core.gui.menu;
 
 /**
- * Different layers of the menu.
+ * Layer constants for menus.
  */
-public enum MenuLayer {
-    /**
-     * Right at the back.
-     */
-    BACKGROUND,
+public final class MenuLayer {
+    /** Right at the back. */
+    public static final int BACKGROUND = 0;
 
-    /**
-     * Second from the back.
-     */
-    LOWER,
+    /** Second from the back. */
+    public static final int LOWER = 1;
 
-    /**
-     * In the middle (default).
-     */
-    MIDDLE,
+    /** In the middle (default). */
+    public static final int MIDDLE = 2;
 
-    /**
-     * Near the top.
-     */
-    UPPER,
+    /** Near the top. */
+    public static final int UPPER = 3;
 
-    /**
-     * At the absolute top.
-     */
-    TOP
+    /** At the absolute top. */
+    public static final int TOP = 4;
+
+    private MenuLayer() {}
 }

--- a/eco-api/src/main/java/com/willfp/eco/core/gui/page/PageBuilder.java
+++ b/eco-api/src/main/java/com/willfp/eco/core/gui/page/PageBuilder.java
@@ -42,21 +42,19 @@ public interface PageBuilder {
         return this.addComponent(row, column, slot);
     }
 
-
     /**
      * Add a component.
      *
-     * @param layer     The layer.
+     * @param layer     The layer, see {@link MenuLayer} for constants.
      * @param row       The row of the top left corner.
      * @param column    The column of the top left corner.
      * @param component The component.
      * @return The builder.
      */
-    PageBuilder addComponent(@NotNull MenuLayer layer,
+    PageBuilder addComponent(int layer,
                              int row,
                              int column,
                              @NotNull GUIComponent component);
-
 
     /**
      * Add a component.

--- a/eco-core/core-backend/src/main/kotlin/com/willfp/eco/internal/gui/menu/EcoMenuBuilder.kt
+++ b/eco-core/core-backend/src/main/kotlin/com/willfp/eco/internal/gui/menu/EcoMenuBuilder.kt
@@ -5,7 +5,6 @@ import com.willfp.eco.core.gui.menu.CloseHandler
 import com.willfp.eco.core.gui.menu.Menu
 import com.willfp.eco.core.gui.menu.MenuBuilder
 import com.willfp.eco.core.gui.menu.MenuEventHandler
-import com.willfp.eco.core.gui.menu.MenuLayer
 import com.willfp.eco.core.gui.menu.OpenHandler
 import com.willfp.eco.util.StringUtils
 import org.bukkit.entity.Player
@@ -17,7 +16,7 @@ class EcoMenuBuilder(
     private val columns: Int
 ) : MenuBuilder {
     private var title = "Menu"
-    private val components = mutableMapOf<MenuLayer, MutableMap<GUIPosition, MutableList<GUIComponent>>>()
+    private val components = mutableMapOf<Int, MutableMap<GUIPosition, MutableList<GUIComponent>>>()
     private val onClose = mutableListOf<CloseHandler>()
     private val onOpen = mutableListOf<OpenHandler>()
     private val onRender = mutableListOf<(Player, Menu) -> Unit>()
@@ -37,7 +36,7 @@ class EcoMenuBuilder(
         return title
     }
 
-    override fun addComponent(layer: MenuLayer, row: Int, column: Int, component: GUIComponent): MenuBuilder {
+    override fun addComponent(layer: Int, row: Int, column: Int, component: GUIComponent): MenuBuilder {
         require(row in 1..rows) { "Invalid row number!" }
         require(column in 1..columns) { "Invalid column number!" }
 
@@ -95,10 +94,10 @@ class EcoMenuBuilder(
         val layeredComponents = LayeredComponents()
 
         // 5 nested for loops? Shut up. Silence. Quiet.
-        for (layer in MenuLayer.entries) {
+        for ((layer, layerComponents) in components.entries.sortedBy { it.key }) {
             for (row in (1..rows)) {
                 for (column in (1..columns)) {
-                    for ((anchor, availableComponents) in components.computeIfAbsent(layer) { mutableMapOf() }) {
+                    for ((anchor, availableComponents) in layerComponents) {
                         for (component in availableComponents) {
                             val rowOffset = 1 + row - anchor.row
                             val columnOffset = 1 + column - anchor.column

--- a/eco-core/core-backend/src/main/kotlin/com/willfp/eco/internal/gui/menu/LayeredComponents.kt
+++ b/eco-core/core-backend/src/main/kotlin/com/willfp/eco/internal/gui/menu/LayeredComponents.kt
@@ -1,17 +1,16 @@
 package com.willfp.eco.internal.gui.menu
 
 import com.willfp.eco.core.gui.menu.Menu
-import com.willfp.eco.core.gui.menu.MenuLayer
 import com.willfp.eco.core.gui.slot.Slot
 import org.bukkit.entity.Player
 
 class LayeredComponents {
-    private val layers = mutableMapOf<MenuLayer, Map<GUIPosition, List<OffsetComponent>>>()
+    private val layers = mutableMapOf<Int, Map<GUIPosition, List<OffsetComponent>>>()
 
     fun getSlotAt(row: Int, column: Int, player: Player?, menu: Menu): Slot {
         val guiPosition = GUIPosition(row, column)
 
-        for (layer in MenuLayer.entries.reversed()) {
+        for (layer in layers.keys.sortedDescending()) {
             val componentsAtPoints = layers[layer] ?: continue
 
             val components = componentsAtPoints[guiPosition] ?: continue
@@ -36,7 +35,7 @@ class LayeredComponents {
         return emptyFillerSlot
     }
 
-    fun addOffsetComponent(layer: MenuLayer, position: GUIPosition, component: OffsetComponent) {
+    fun addOffsetComponent(layer: Int, position: GUIPosition, component: OffsetComponent) {
         val inLayer = layers[layer]?.toMutableMap() ?: mutableMapOf()
         val atPosition = inLayer[position]?.toMutableList() ?: mutableListOf()
         atPosition.add(component)


### PR DESCRIPTION
Changed Menu building logic to be integer layers over predefined enum entries.

Also converted `MenuLayer` from an enum to a final class with named `int` constants:
- BACKGROUND=0
- LOWER=1
- MIDDLE=2
- UPPER=3
- TOP=4

