### PR TITLE
fix: Reload Command Registry

### DIFF
--- a/eco-api/src/main/java/com/willfp/eco/core/Eco.java
+++ b/eco-api/src/main/java/com/willfp/eco/core/Eco.java
@@ -570,6 +570,23 @@ public interface Eco {
     void syncCommands();
 
     /**
+     * Begin a batch of command (un)registrations. While a batch is open,
+     * {@link #syncCommands()} calls are deferred and coalesced into a single
+     * sync when the batch closes.
+     *
+     * <p>Nestable — requires a matching {@link #endCommandBatch()} per call.
+     * Must be called from the main thread.
+     */
+    void beginCommandBatch();
+
+    /**
+     * End a batch opened with {@link #beginCommandBatch()}. When the outermost
+     * batch closes, a single {@link #syncCommands()} runs if any sync was
+     * requested during the batch.
+     */
+    void endCommandBatch();
+
+    /**
      * Unregister a command.
      *
      * @param command The command.

--- a/eco-api/src/main/java/com/willfp/eco/core/EcoPlugin.java
+++ b/eco-api/src/main/java/com/willfp/eco/core/EcoPlugin.java
@@ -435,7 +435,12 @@ public abstract class EcoPlugin extends JavaPlugin implements PluginLike, Regist
         this.loadListeners().forEach(listener -> this.getEventManager().registerListener(listener));
         this.loadPacketListeners().forEach(listener -> this.getEventManager().registerPacketListener(listener));
 
-        this.loadPluginCommands().forEach(PluginCommand::register);
+        Eco.get().beginCommandBatch();
+        try {
+            this.loadPluginCommands().forEach(PluginCommand::register);
+        } finally {
+            Eco.get().endCommandBatch();
+        }
 
         // Run preliminary reload to resolve load order issues
         this.getScheduler().runLater(() -> {

--- a/eco-core/core-backend/src/main/kotlin/com/willfp/eco/internal/command/EcoPluginCommand.kt
+++ b/eco-core/core-backend/src/main/kotlin/com/willfp/eco/internal/command/EcoPluginCommand.kt
@@ -21,7 +21,7 @@ class EcoPluginCommand(
         val knownAliases = command?.aliases ?: aliases
 
         if (command == null) {
-            unregister()
+            unregisterWithoutSync()
             commandMap.register(plugin.name.lowercase(), DelegatedBukkitCommand(this))
         } else {
             command.setExecutor(this)
@@ -34,10 +34,13 @@ class EcoPluginCommand(
     }
 
     override fun unregister() {
+        unregisterWithoutSync()
+        Eco.get().syncCommands()
+    }
+
+    private fun unregisterWithoutSync() {
         commandMap.getCommand(name)?.unregister(commandMap)
         Eco.get().unregisterCommand(this)
-
-        Eco.get().syncCommands()
     }
 
     override fun getAliases(): List<String> = parentDelegate.aliases

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/EcoImpl.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/EcoImpl.kt
@@ -340,8 +340,29 @@ class EcoImpl : EcoSpigotPlugin(), Eco {
         return this.getProxy(CommonsInitializerProxy::class.java).removeBukkitRecipeNoResend(key)
     }
 
-    override fun syncCommands() =
+    private var batchDepth = 0
+    private var syncDuringBatch = false
+
+    override fun syncCommands() {
+        if (batchDepth > 0) {
+            syncDuringBatch = true
+            return
+        }
         this.getProxy(BukkitCommandsProxy::class.java).syncCommands()
+    }
+
+    override fun beginCommandBatch() {
+        batchDepth++
+    }
+
+    override fun endCommandBatch() {
+        check(batchDepth > 0) { "endCommandBatch() called without matching beginCommandBatch()" }
+        batchDepth--
+        if (batchDepth == 0 && syncDuringBatch) {
+            syncDuringBatch = false
+            this.getProxy(BukkitCommandsProxy::class.java).syncCommands()
+        }
+    }
 
     override fun unregisterCommand(command: PluginCommandBase) =
         this.getProxy(BukkitCommandsProxy::class.java).unregisterCommand(command)


### PR DESCRIPTION
## Addresses:
<img width="488" height="391" alt="{0EA91ECC-9EDE-47E4-B200-D5C97B8EBA3E}" src="https://github.com/user-attachments/assets/899b0b0d-203a-473f-9f30-8ec4ab856ed0" />

## Summary
Fixed command registration and deregistration on reload (/<plugin> reload).