### PR TITLE
fix: Prevent health restoration for dead players in PlayerHealthPatch

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/eventlisteners/PlayerHealthPatch.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/eventlisteners/PlayerHealthPatch.kt
@@ -19,7 +19,9 @@ object PlayerHealthPatch: Listener {
     fun handlePlayerJoin(event: PlayerJoinEvent) {
         if (Eco.get().ecoPlugin.configYml.getBool("enable-health-fix")) {
             Eco.get().ecoPlugin.scheduler.runLater(5L) {
-                event.player.health = event.player.savedHealth
+                if (!event.player.isDead) {
+                    event.player.health = event.player.savedHealth
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes issue where dead players get their health restored, causing issues particuluarly with PvP plugin tagging.

User confirmed working fine: https://discord.com/channels/452518336627081236/1505318957421166633