### PR TITLE
Migrate CoinsEngine to ExcellentEconomy

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -101,7 +101,7 @@ allprojects {
         // CraftEngine
         maven("https://repo.momirealms.net/releases/")
 
-        // CoinsEngine
+        // ExcellentEconomy and ExcellentShop
         maven("https://repo.nightexpressdev.com/releases")
 
         //Towny

--- a/eco-api/src/main/java/com/willfp/eco/core/EcoPlugin.java
+++ b/eco-api/src/main/java/com/willfp/eco/core/EcoPlugin.java
@@ -19,6 +19,7 @@ import com.willfp.eco.core.integrations.IntegrationLoader;
 import com.willfp.eco.core.map.ListMap;
 import com.willfp.eco.core.packet.PacketListener;
 import com.willfp.eco.core.proxy.ProxyFactory;
+import com.willfp.eco.core.price.Prices;
 import com.willfp.eco.core.registry.Registrable;
 import com.willfp.eco.core.registry.Registry;
 import com.willfp.eco.core.scheduling.Scheduler;
@@ -422,7 +423,8 @@ public abstract class EcoPlugin extends JavaPlugin implements PluginLike, Regist
         this.loadedIntegrations.removeIf(pl -> pl.equalsIgnoreCase(this.getName()));
 
         if (!this.getLoadedIntegrations().isEmpty()) {
-            this.getLogger().info("Loaded integrations: " + String.join(", ", this.getLoadedIntegrations()));
+            this.getLogger().info("Loaded integrations (" + this.getLoadedIntegrations().size() + "): "
+                    + String.join(", ", this.getLoadedIntegrations()));
         }
 
         Prerequisite.update();
@@ -459,10 +461,17 @@ public abstract class EcoPlugin extends JavaPlugin implements PluginLike, Regist
                 ).toList();
 
                 this.getLogger().info(
-                        "Loaded extensions: " +
-                                String.join(", ", loadedExtensions)
+                        "Loaded extensions (" + loadedExtensions.size() + "): "
+                               + String.join(", ", loadedExtensions)
                 );
             }
+        }
+
+        if (!Prices.allLoadedFactories().isEmpty()) {
+            this.getLogger().info(
+                    "Loaded price factories (" + Prices.allLoadedFactories().size() + "): "
+                            + String.join(", ", Prices.allLoadedFactories())
+            );
         }
 
         this.handleLifecycle(this.onEnable, this::handleEnable);

--- a/eco-api/src/main/java/com/willfp/eco/core/price/Prices.java
+++ b/eco-api/src/main/java/com/willfp/eco/core/price/Prices.java
@@ -40,7 +40,15 @@ public final class Prices {
      */
     public static void registerPriceFactory(@NotNull final PriceFactory factory) {
         for (String name : factory.getNames()) {
-            FACTORIES.put(name.toLowerCase(), factory);
+            String key = name.toLowerCase();
+            PriceFactory existing = FACTORIES.get(key);
+            if (existing != null && existing != factory) {
+                throw new IllegalStateException(String.format(
+                        "A price factory is already registered under the name '%s' (%s). Cannot register %s.",
+                        key, existing.getClass().getName(), factory.getClass().getName()
+                ));
+            }
+            FACTORIES.put(key, factory);
         }
     }
 

--- a/eco-api/src/main/java/com/willfp/eco/core/price/Prices.java
+++ b/eco-api/src/main/java/com/willfp/eco/core/price/Prices.java
@@ -10,6 +10,7 @@ import com.willfp.eco.core.price.impl.PriceItem;
 import com.willfp.eco.core.recipe.parts.EmptyTestableItem;
 import com.willfp.eco.util.NumberUtils;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -22,6 +23,15 @@ public final class Prices {
      * All factories.
      */
     private static final Map<String, PriceFactory> FACTORIES = new ConcurrentHashMap<>();
+
+    /**
+     * Returns an immutable snapshot of all loaded price factory names.
+     *
+     * @return Immutable set containing all loaded factory names
+     */
+    public static Set<String> allLoadedFactories() {
+        return Set.copyOf(FACTORIES.keySet());
+    }
 
     /**
      * Register a new price factory.

--- a/eco-core/core-plugin/build.gradle.kts
+++ b/eco-core/core-plugin/build.gradle.kts
@@ -121,8 +121,8 @@ dependencies {
     compileOnly("net.william278.husktowns:husktowns-bukkit:3.1.4")
     compileOnly("com.github.jojodmo:ItemBridge:b0054538c1")
     compileOnly("de.oliver:FancyHolograms:2.9.1")
-    compileOnly("su.nightexpress.coinsengine:CoinsEngine:2.7.0")
-    compileOnly("su.nightexpress.nightcore:main:2.14.1")
+    compileOnly("su.nightexpress.excellenteconomy:ExcellentEconomy:2.8.0")
+    compileOnly("su.nightexpress.nightcore:main:2.15.3")
     compileOnly("su.nightexpress.excellentshop:Core:4.22.0")
     compileOnly("dev.kitteh:factions:4.4.0")
 

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/EcoSpigotPlugin.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/EcoSpigotPlugin.kt
@@ -545,7 +545,7 @@ abstract class EcoSpigotPlugin : EcoPlugin() {
                     }
                 }
             },
-            IntegrationLoader("CoinsEngine") {
+            IntegrationLoader("ExcellentEconomy") {
                 val rsp = Bukkit.getServer().servicesManager.getRegistration(ExcellentEconomyAPI::class.java)
                 if (rsp != null) {
                     val api = rsp.provider

--- a/eco-core/core-plugin/src/main/resources/plugin.yml
+++ b/eco-core/core-plugin/src/main/resources/plugin.yml
@@ -63,7 +63,7 @@ softdepend:
   - RoyaleEconomy
   - FancyHolograms
   - CraftEngine
-  - CoinsEngine
+  - ExcellentEconomy
   - ExcellentShop
 
 libraries:


### PR DESCRIPTION
Replace CoinsEngine integration with ExcellentEconomy:
- update integration loader, and plugin softdepend
- dependency changes: ExcellentEconomy 2.8.0 and NightCore upgraded to 2.15.3
- added some helpful logs on plugin startup for easier debugging

This PR fixes/imroves the Auxilor/eco#459
