### PR TITLE
fancyplugins.de has changed to fancyinnovations.com, dependencies for eco compilation fail and plugin wouldn't build.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,7 +93,7 @@ allprojects {
         maven("https://repo.william278.net/releases")
 
         // FancyHolograms
-        maven("https://repo.fancyplugins.de/releases")
+        maven("https://repo.fancyinnovations.de/releases")
 
         // Nexo
         maven("https://repo.nexomc.com/releases")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,7 +93,7 @@ allprojects {
         maven("https://repo.william278.net/releases")
 
         // FancyHolograms
-        maven("https://repo.fancyinnovations.de/releases")
+        maven("https://repo.fancyinnovations.com/releases")
 
         // Nexo
         maven("https://repo.nexomc.com/releases")


### PR DESCRIPTION
changed repository to new domain