### PR TITLE
fix: Admonition format

### DIFF
--- a/documentation/all-plugins/sounds.md
+++ b/documentation/all-plugins/sounds.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Sound Configs
 sidebar_position: 9
 ---
@@ -45,6 +45,6 @@ Sometimes you might choose to disable the config sound and use an effect to play
 We can use the Boosters plugin as an example here. In the config.yml, you can configure a sound to play when a booster is activated, but this would apply to all boosters. <br/>
 If you wanted a specific sound to play for the "1.5x Sell Booster", you could instead add a `play_sound` effect to the `activation-effects` section of the booster config, and this sound would only play when that specific booster is activated.
 
-:::noteCustom Sounds
+:::note Custom Sounds
 Currently we only support Bukkit sounds, but we are looking into adding support for custom sounds in the future.
 :::

--- a/documentation/custom-entity-ai/all-entity-goals/ecomobs_random_teleport.md
+++ b/documentation/custom-entity-ai/all-entity-goals/ecomobs_random_teleport.md
@@ -1,5 +1,5 @@
-# `ecomobs:random_teleport`
-:::infoRequires:
+﻿# `ecomobs:random_teleport`
+:::info Requires:
 EcoMobs
 :::
 

--- a/documentation/lookup-systems/the-item-lookup-system/external-item-integrations.md
+++ b/documentation/lookup-systems/the-item-lookup-system/external-item-integrations.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: External Item Integrations
 slug: /the-item-lookup-system/external-item-integrations
 sidebar_position: 1
@@ -22,7 +22,7 @@ To use external items within The Item Lookup System, you need to use the relevan
 | Oraxen          | `oraxen:<id>`                                                                                                              |
 | Nexo            | `nexo:<id>`                                                                                                                |
 
-:::tipOther Plugins
+:::tip Other Plugins
 Remember, you can use NBT data for any other items where there is not direct plugin integration. Check out our [NBT converter](https://plugins.auxilor.io/the-item-lookup-system/nbt-string-creator).
 :::
 

--- a/documentation/lookup-systems/the-item-lookup-system/recipes.md
+++ b/documentation/lookup-systems/the-item-lookup-system/recipes.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Crafting Recipes
 slug: /the-item-lookup-system/recipes
 sidebar_position: 1
@@ -79,7 +79,7 @@ recipe:
   - "netherite_ingot"
   ```
 
-:::tipInvisible Recipe Results
+:::tip Invisible Recipe Results
 When using non-vanilla custom items in crafting recipes, the result may sometimes appear invisible. <br/>
 Although it looks like the recipe is broken and produces no result, clicking the result slot will still give you the correct item.
 
@@ -87,13 +87,13 @@ To fix this, open `/plugins/eco/config.yml` and find the `enforce-preparing-reci
 :::
 
 
-:::noteCreating Multiple Recipes
+:::note Creating Multiple Recipes
 Creating multiple recipes for one item is not supported in the current config structure.
 
 However, if you own EcoItems, you can easily create more custom recipes, you can read about that [here](https://plugins.auxilor.io/ecoitems/additional-configuration-options#how-to-add-additional-recipes).
 :::
 
-:::warningRecipe Book
+:::warning Recipe Book
 There is a display issue where only vanilla items are shown in the recipe book, and heads use the default texture. However, the recipes still work correctly.
 This is a Minecraft/Server limitation due to how custom items are handled. There were events of servers crashing and corrupting chunks when displaying custom items in recipes.
 


### PR DESCRIPTION
Fixes missing space between admonition type and title in documentation.