### PR TITLE
Remove Lands from loadbefore to prevent circular plugin loading

### DIFF
--- a/eco-core/core-plugin/src/main/resources/plugin.yml
+++ b/eco-core/core-plugin/src/main/resources/plugin.yml
@@ -8,71 +8,71 @@ load: STARTUP
 
 # Fixes some plugins breaking load order
 loadbefore:
-- Spartan
-- CustomCrafting
-- EconomyShopGUI
-- EconomyShopGUI-Premium
-- CMI
-- DeluxeCombat
-- ShopGUIPlus
-- DeluxeMenus
+  - Spartan
+  - CustomCrafting
+  - EconomyShopGUI
+  - EconomyShopGUI-Premium
+  - CMI
+  - DeluxeCombat
+  - ShopGUIPlus
+  - DeluxeMenus
 softdepend:
-- ItemBridge
-- HuskClaims
-- HuskTowns
-- Terra
-- ProtocolLib
-- WorldGuard
-- GriefPrevention
-- Towny
-- FactionsUUID
-- Kingdoms
-- AAC
-- Matrix
-- Vulcan
-- PlaceholderAPI
-- mcMMO
-- CombatLogX
-- ItemsAdder
-- Oraxen
-- Nexo
-- HeadDatabase
-- Multiverse-Inventories
-- Alice
-- HolographicDisplays
-- GHolo
-- Essentials
-- Vault
-- BentoBox
-- IridiumSkyblock
-- SuperiorSkyblock2
-- FabledSkyBlock
-- DecentHolograms
-- MythicMobs
-- RPGHorses
-- zShop
-- DeluxeSellwands
-- Scyther
-- ModelEngine
-- PvPManager
-- DeluxeMenus
-- UltraEconomy
-- PlayerPoints
-- Denizen
-- RoyaleEconomy
-- FancyHolograms
-- CraftEngine
-- ExcellentEconomy
-- ExcellentShop
+  - ItemBridge
+  - HuskClaims
+  - HuskTowns
+  - Terra
+  - ProtocolLib
+  - WorldGuard
+  - GriefPrevention
+  - Towny
+  - FactionsUUID
+  - Kingdoms
+  - AAC
+  - Matrix
+  - Vulcan
+  - PlaceholderAPI
+  - mcMMO
+  - CombatLogX
+  - ItemsAdder
+  - Oraxen
+  - Nexo
+  - HeadDatabase
+  - Multiverse-Inventories
+  - Alice
+  - HolographicDisplays
+  - GHolo
+  - Essentials
+  - Vault
+  - BentoBox
+  - IridiumSkyblock
+  - SuperiorSkyblock2
+  - FabledSkyBlock
+  - DecentHolograms
+  - MythicMobs
+  - RPGHorses
+  - zShop
+  - DeluxeSellwands
+  - Scyther
+  - ModelEngine
+  - PvPManager
+  - DeluxeMenus
+  - UltraEconomy
+  - PlayerPoints
+  - Denizen
+  - RoyaleEconomy
+  - FancyHolograms
+  - CraftEngine
+  - ExcellentEconomy
+  - ExcellentShop
 
 libraries:
-- com.mysql:mysql-connector-j:9.6.0
-- org.mariadb.jdbc:mariadb-java-client:2.7.12
-- com.zaxxer:HikariCP:7.0.2
-- net.kyori:adventure-platform-bukkit:4.4.1
-- org.mongodb:mongodb-driver-kotlin-coroutine:5.6.2
-- io.hotmoka:toml4j:0.7.3
-- net.kyori:adventure-api:5.0.1
-- net.kyori:adventure-text-serializer-gson:5.0.1
-- net.kyori:adventure-text-serializer-legacy:5.0.1
-- com.github.ben-manes.caffeine:caffeine:3.2.3
+  - com.mysql:mysql-connector-j:9.6.0
+  - org.mariadb.jdbc:mariadb-java-client:2.7.12
+  - com.zaxxer:HikariCP:7.0.2
+  - net.kyori:adventure-platform-bukkit:4.4.1
+  - org.mongodb:mongodb-driver-kotlin-coroutine:5.6.2
+  - io.hotmoka:toml4j:0.7.3
+  - net.kyori:adventure-api:5.0.1
+  - net.kyori:adventure-text-serializer-gson:5.0.1
+  - net.kyori:adventure-text-serializer-legacy:5.0.1
+  - com.github.ben-manes.caffeine:caffeine:3.2.3

--- a/eco-core/core-plugin/src/main/resources/plugin.yml
+++ b/eco-core/core-plugin/src/main/resources/plugin.yml
@@ -8,72 +8,71 @@ load: STARTUP
 
 # Fixes some plugins breaking load order
 loadbefore:
-  - Spartan
-  - CustomCrafting
-  - Lands
-  - EconomyShopGUI
-  - EconomyShopGUI-Premium
-  - CMI
-  - DeluxeCombat
-  - ShopGUIPlus
-  - DeluxeMenus
+- Spartan
+- CustomCrafting
+- EconomyShopGUI
+- EconomyShopGUI-Premium
+- CMI
+- DeluxeCombat
+- ShopGUIPlus
+- DeluxeMenus
 softdepend:
-  - ItemBridge
-  - HuskClaims
-  - HuskTowns
-  - Terra
-  - ProtocolLib
-  - WorldGuard
-  - GriefPrevention
-  - Towny
-  - FactionsUUID
-  - Kingdoms
-  - AAC
-  - Matrix
-  - Vulcan
-  - PlaceholderAPI
-  - mcMMO
-  - CombatLogX
-  - ItemsAdder
-  - Oraxen
-  - Nexo
-  - HeadDatabase
-  - Multiverse-Inventories
-  - Alice
-  - HolographicDisplays
-  - GHolo
-  - Essentials
-  - Vault
-  - BentoBox
-  - IridiumSkyblock
-  - SuperiorSkyblock2
-  - FabledSkyBlock
-  - DecentHolograms
-  - MythicMobs
-  - RPGHorses
-  - zShop
-  - DeluxeSellwands
-  - Scyther
-  - ModelEngine
-  - PvPManager
-  - DeluxeMenus
-  - UltraEconomy
-  - PlayerPoints
-  - Denizen
-  - RoyaleEconomy
-  - FancyHolograms
-  - CraftEngine
-  - ExcellentEconomy
-  - ExcellentShop
+- ItemBridge
+- HuskClaims
+- HuskTowns
+- Terra
+- ProtocolLib
+- WorldGuard
+- GriefPrevention
+- Towny
+- FactionsUUID
+- Kingdoms
+- AAC
+- Matrix
+- Vulcan
+- PlaceholderAPI
+- mcMMO
+- CombatLogX
+- ItemsAdder
+- Oraxen
+- Nexo
+- HeadDatabase
+- Multiverse-Inventories
+- Alice
+- HolographicDisplays
+- GHolo
+- Essentials
+- Vault
+- BentoBox
+- IridiumSkyblock
+- SuperiorSkyblock2
+- FabledSkyBlock
+- DecentHolograms
+- MythicMobs
+- RPGHorses
+- zShop
+- DeluxeSellwands
+- Scyther
+- ModelEngine
+- PvPManager
+- DeluxeMenus
+- UltraEconomy
+- PlayerPoints
+- Denizen
+- RoyaleEconomy
+- FancyHolograms
+- CraftEngine
+- ExcellentEconomy
+- ExcellentShop
 
 libraries:
-  - com.mysql:mysql-connector-j:9.6.0
-  - org.mariadb.jdbc:mariadb-java-client:2.7.12
-  - com.zaxxer:HikariCP:7.0.2
-  - net.kyori:adventure-platform-bukkit:4.4.1
-  - org.mongodb:mongodb-driver-kotlin-coroutine:5.6.2
-  - io.hotmoka:toml4j:0.7.3
-  - net.kyori:adventure-api:5.0.1
-  - net.kyori:adventure-text-serializer-gson:5.0.1
-  - net.kyori:adventure-text-serializer-legacy:5.0.1
-  - com.github.ben-manes.caffeine:caffeine:3.2.3
+- com.mysql:mysql-connector-j:9.6.0
+- org.mariadb.jdbc:mariadb-java-client:2.7.12
+- com.zaxxer:HikariCP:7.0.2
+- net.kyori:adventure-platform-bukkit:4.4.1
+- org.mongodb:mongodb-driver-kotlin-coroutine:5.6.2
+- io.hotmoka:toml4j:0.7.3
+- net.kyori:adventure-api:5.0.1
+- net.kyori:adventure-text-serializer-gson:5.0.1
+- net.kyori:adventure-text-serializer-legacy:5.0.1
+- com.github.ben-manes.caffeine:caffeine:3.2.3


### PR DESCRIPTION
## Description

This PR removes `Lands` from eco's `loadbefore` list in `eco-core/core-plugin/src/main/resources/plugin.yml`.

When eco, Lands and Nexo are installed together, Paper detects a circular plugin loading relationship during startup.

## Reported issue

```log
[LoadOrderTree] Circular plugin loading detected:
[LoadOrderTree] 1) eco -> HeadDatabase -> Nexo -> Lands -> eco
[LoadOrderTree]    eco loadbefore: [..., Lands, ...]
[LoadOrderTree]    eco depend/softdepend: [..., Nexo, HeadDatabase, ...]
[LoadOrderTree]    HeadDatabase depend/softdepend: [..., Nexo]
[LoadOrderTree]    Nexo loadafter: [..., Lands, ...]
```

The minimal cycle is caused by the following load-order constraints:

```text
eco loadbefore Lands  -> eco loads before Lands
Nexo loadafter Lands  -> Lands loads before Nexo
eco softdepend Nexo   -> Nexo loads before eco
```

Which results in:

```text
eco -> Lands -> Nexo -> eco
```

## Change made

```diff
 loadbefore:
   - Spartan
   - CustomCrafting
-  - Lands
   - EconomyShopGUI
   - EconomyShopGUI-Premium
   - CMI
   - DeluxeCombat
   - ShopGUIPlus
   - DeluxeMenus
```

## Why this change

eco's Lands integration is still loaded normally through its existing integration system. This change does not remove or disable Lands support; it only removes the forced ordering that causes the circular dependency when Nexo is present.

The Lands integration used by eco reads existing Lands protection data for anti-grief checks. It does not appear to require eco to be loaded before Lands.

## Testing

Test environment:

* Paper: `26.1.2` build `66`
* eco: `7.6.1`
* Lands: `7.26.1`
* Nexo: `1.24`
* HeadDatabase: `4.23.0`

Before this change:

* Paper reported `Circular plugin loading detected` during startup.

After removing `Lands` from `loadbefore` and restarting the server:

* No `Circular plugin loading detected` error was reported.
* eco continued to load its integrations, including Lands and Nexo.

## Logs and environment information

Full startup log:
https://mclo.gs/NCZnNmY

Spark report:
https://spark.lucko.me/7SuamkQsk2
