### PR TITLE
Fix: health reset on join

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/eventlisteners/PlayerHealthPatch.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/eventlisteners/PlayerHealthPatch.kt
@@ -21,19 +21,23 @@ object PlayerHealthPatch: Listener {
     @EventHandler(priority = EventPriority.MONITOR)
     fun handlePlayerJoin(event: PlayerJoinEvent) {
 		if (Eco.get().ecoPlugin.configYml.getBool("enable-health-fix")) {
-			val fixDuration = Eco.get().ecoPlugin.configYml.getInt("health-fix-duration", 3)
+			var fixDuration = Eco.get().ecoPlugin.configYml.getInt("health-fix-duration", 3)
+			if (fixDuration <= 0) fixDuration = 3
 
-			val previousMax = event.player.getAttribute(Attribute.MAX_HEALTH)?.value ?: 20.0
+			var fixInterval = Eco.get().ecoPlugin.configYml.getInt("health-fix-interval", 1)
+			if (fixInterval <= 0) fixInterval = 1
+			else if (fixInterval > fixDuration) fixInterval = fixDuration
+
+			// ceil fix for int
+			var timesToRun = (fixDuration + fixInterval - 1) / fixInterval
+
+			var previousMax = event.player.getAttribute(Attribute.MAX_HEALTH)?.value ?: 20.0
 
 			// Run every tick for up to user defined duration in config.
 			var repeatingTask: BukkitTask? = null
-			var ticksRan = 0
 			repeatingTask = Eco.get().ecoPlugin.scheduler.runTimer({
 				try {
-					ticksRan++
-
-					// 3 sec = 60 tick (as 1 sec = 20 tick)
-					if (ticksRan >= fixDuration * 20) {
+					if (timesToRun <= 0) {
 						repeatingTask?.cancel()
 						return@runTimer
 					}
@@ -49,11 +53,16 @@ object PlayerHealthPatch: Listener {
 						val newHealth = getNewHealth(currentHealth, savedHealth, currentMax, previousMax)
 
 						event.player.health = newHealth
+
+						previousMax = currentMax
 					}
 				} catch (ex: Exception) {
 					Eco.get().ecoPlugin.logger.warning("Exception while monitoring health attribute: ${ex.message}")
+				} finally {
+					timesToRun--;
 				}
-			}, 1L, 1L)
+
+			}, 1L, fixInterval * 20L)
 		}
 	}
 

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/eventlisteners/PlayerHealthPatch.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/eventlisteners/PlayerHealthPatch.kt
@@ -15,18 +15,57 @@ object PlayerHealthPatch: Listener {
     @EventHandler(priority = EventPriority.LOWEST)
     fun handlePlayerQuit(event: PlayerQuitEvent) {
         event.player.saveHealth()
-    }
+	}
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR)
     fun handlePlayerJoin(event: PlayerJoinEvent) {
-        if (Eco.get().ecoPlugin.configYml.getBool("enable-health-fix")) {
-            Eco.get().ecoPlugin.scheduler.runLater(5L) {
-                if (!event.player.isDead) {
-                    event.player.health = min(event.player.savedHealth,
-                        event.player.getAttribute(Attribute.MAX_HEALTH)?.value
-                            ?: 20.0)
-                }
-            }
-        }
-    }
+		if (Eco.get().ecoPlugin.configYml.getBool("enable-health-fix")) {
+			// Start a short repeating task to detect attribute changes as soon as they are applied.
+			// Keep it active for a fixed window so multiple delayed changes to MAX_HEALTH attribute can be handled.
+			val initialMax = event.player.getAttribute(Attribute.MAX_HEALTH)?.value ?: 20.0
+			val previousMax = initialMax
+
+			// Run every tick for up to 100 ticks (~5s).
+			var repeatingTask: org.bukkit.scheduler.BukkitTask? = null
+			var ticksRan = 0
+			repeatingTask = Eco.get().ecoPlugin.scheduler.runTimer({
+				try {
+					ticksRan++
+					// 100 ticks = 5 sec
+					if (ticksRan >= 100) {
+						repeatingTask?.cancel()
+						return@runTimer
+					}
+
+					if (!event.player.isOnline || event.player.isDead) return@runTimer
+
+					val currentMax = event.player.getAttribute(Attribute.MAX_HEALTH)?.value ?: 20.0
+					if (currentMax != previousMax) {
+						// Max health changed.
+						val oldMax = previousMax
+						val currentHealth = event.player.health
+
+						val newHealth = if (oldMax <= 0.0) {
+							// Fallback: set to current max or saved health
+							min(event.player.savedHealth, currentMax)
+						} else {
+							// If player was at (or very near) full health before the change, top them up to the new max.
+							if (currentHealth >= oldMax - 0.0001) {
+								min(event.player.savedHealth, currentMax)
+							} else {
+								// Otherwise, preserve the same percentage of health.
+								val pct = currentHealth / oldMax
+								min(currentMax * pct, currentMax)
+							}
+						}
+
+						Eco.get().ecoPlugin.logger.info("[HEALTH-FIX] Detected MAX_HEALTH change from $oldMax to $currentMax for ${event.player.name}. Setting health to $newHealth")
+						event.player.health = newHealth
+					}
+				} catch (ex: Exception) {
+					Eco.get().ecoPlugin.logger.warning("[HEALTH-FIX] Exception while monitoring health attribute: ${ex.message}")
+				}
+			}, 1L, 1L)
+		}
+	}
 }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/eventlisteners/PlayerHealthPatch.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/eventlisteners/PlayerHealthPatch.kt
@@ -9,6 +9,7 @@ import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
 import org.bukkit.event.player.PlayerJoinEvent
 import org.bukkit.event.player.PlayerQuitEvent
+import org.bukkit.scheduler.BukkitTask
 import kotlin.math.min
 
 object PlayerHealthPatch: Listener {
@@ -20,19 +21,19 @@ object PlayerHealthPatch: Listener {
     @EventHandler(priority = EventPriority.MONITOR)
     fun handlePlayerJoin(event: PlayerJoinEvent) {
 		if (Eco.get().ecoPlugin.configYml.getBool("enable-health-fix")) {
-			// Start a short repeating task to detect attribute changes as soon as they are applied.
-			// Keep it active for a fixed window so multiple delayed changes to MAX_HEALTH attribute can be handled.
-			val initialMax = event.player.getAttribute(Attribute.MAX_HEALTH)?.value ?: 20.0
-			val previousMax = initialMax
+			val fixDuration = Eco.get().ecoPlugin.configYml.getInt("health-fix-duration", 3)
 
-			// Run every tick for up to 100 ticks (~5s).
-			var repeatingTask: org.bukkit.scheduler.BukkitTask? = null
+			val previousMax = event.player.getAttribute(Attribute.MAX_HEALTH)?.value ?: 20.0
+
+			// Run every tick for up to user defined duration in config.
+			var repeatingTask: BukkitTask? = null
 			var ticksRan = 0
 			repeatingTask = Eco.get().ecoPlugin.scheduler.runTimer({
 				try {
 					ticksRan++
-					// 100 ticks = 5 sec
-					if (ticksRan >= 100) {
+
+					// 3 sec = 60 tick (as 1 sec = 20 tick)
+					if (ticksRan >= fixDuration * 20) {
 						repeatingTask?.cancel()
 						return@runTimer
 					}
@@ -42,29 +43,37 @@ object PlayerHealthPatch: Listener {
 					val currentMax = event.player.getAttribute(Attribute.MAX_HEALTH)?.value ?: 20.0
 					if (currentMax != previousMax) {
 						// Max health changed.
-						val oldMax = previousMax
 						val currentHealth = event.player.health
-
-						val newHealth = if (oldMax <= 0.0) {
-							// Fallback: set to current max or saved health
-							min(event.player.savedHealth, currentMax)
-						} else {
-							// If player was at (or very near) full health before the change, top them up to the new max.
-							if (currentHealth >= oldMax - 0.0001) {
-								min(event.player.savedHealth, currentMax)
-							} else {
-								// Otherwise, preserve the same percentage of health.
-								val pct = currentHealth / oldMax
-								min(currentMax * pct, currentMax)
-							}
-						}
+						val savedHealth = event.player.savedHealth
+						// Get new health based on logic checks
+						val newHealth = getNewHealth(currentHealth, savedHealth, currentMax, previousMax)
 
 						event.player.health = newHealth
 					}
 				} catch (ex: Exception) {
-					Eco.get().ecoPlugin.logger.warning("[HEALTH-FIX] Exception while monitoring health attribute: ${ex.message}")
+					Eco.get().ecoPlugin.logger.warning("Exception while monitoring health attribute: ${ex.message}")
 				}
 			}, 1L, 1L)
+		}
+	}
+
+	fun getNewHealth(currentHealth : Double,
+					 savedHealth : Double,
+					 currentMax : Double,
+					 previousMax : Double
+					): Double {
+
+		if (previousMax <= 0.0) {
+			// Fallback: set to current max or saved health
+			return min(savedHealth, currentMax)
+		}
+
+		if (currentHealth >= previousMax) {
+			return min(savedHealth, currentMax)
+		} else {
+			// Otherwise, preserve the same percentage of health.
+			val percent = currentHealth / previousMax
+			return min(currentMax * percent, currentMax)
 		}
 	}
 }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/eventlisteners/PlayerHealthPatch.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/eventlisteners/PlayerHealthPatch.kt
@@ -59,7 +59,6 @@ object PlayerHealthPatch: Listener {
 							}
 						}
 
-						Eco.get().ecoPlugin.logger.info("[HEALTH-FIX] Detected MAX_HEALTH change from $oldMax to $currentMax for ${event.player.name}. Setting health to $newHealth")
 						event.player.health = newHealth
 					}
 				} catch (ex: Exception) {

--- a/eco-core/core-plugin/src/main/resources/config.yml
+++ b/eco-core/core-plugin/src/main/resources/config.yml
@@ -115,3 +115,6 @@ enable-health-fix: true
 # The duration (in seconds) during which the health fix will be applied
 # Requires enable-health-fix to be true.
 health-fix-duration: 3
+
+# The interval (in seconds) at which the health fix will be applied during the duration
+health-fix-interval: 1

--- a/eco-core/core-plugin/src/main/resources/config.yml
+++ b/eco-core/core-plugin/src/main/resources/config.yml
@@ -111,3 +111,7 @@ enforce-preparing-recipes: false
 # If enabled, eco will save the health of players when they log out and restore it when they log back in
 # as a workaround for player health being reset to 20 on login.
 enable-health-fix: true
+
+# The duration (in seconds) during which the health fix will be applied
+# Requires enable-health-fix to be true.
+health-fix-duration: 3


### PR DESCRIPTION
Before it would just check after 5 tick for health update, and it will permanently update the health regardless of old saved health.
Since some plugin might load after eco, there can be issue of health reset bug. (as stated in discord)

I have implemented task to run on interval each tick for 100 tick for health change.