### PR TITLE
repair cost of 0 compatibility

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/anvil/AnvilMechanicsListener.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/anvil/AnvilMechanicsListener.kt
@@ -135,7 +135,7 @@ class AnvilMechanicsListener(
 
             var cost = baseRepairCost + price
             if (baseRepairCost == -price) cost = price
-            if (cost <= 0) return@run
+            if (cost <= 0) cost = 1
 
             val leftEnchants = left?.fast()?.getEnchants(true) ?: emptyMap()
             val outEnchants = outItem.fast().getEnchants(true)


### PR DESCRIPTION
The custom anvil search GUI I use in my own plugin (AuctionHouse plugin) sets the maximum repair cost to 0 and also the repair cost (with a scheduler) to 0 on the PrepareAnvilEvent. Currently, no output item appears. This small fix does the job