### PR TITLE
fix: nexo items not updating ever

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/integrations/customitems/CustomItemsNexo.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/integrations/customitems/CustomItemsNexo.kt
@@ -2,7 +2,6 @@ package com.willfp.eco.internal.spigot.integrations.customitems
 
 import com.nexomc.nexo.api.NexoItems
 import com.nexomc.nexo.api.events.NexoItemsLoadedEvent
-import com.nexomc.nexo.items.UpdateCallback
 import com.willfp.eco.core.EcoPlugin
 import com.willfp.eco.core.integrations.customitems.CustomItemsIntegration
 import com.willfp.eco.core.items.CustomItem
@@ -10,12 +9,9 @@ import com.willfp.eco.core.items.Items
 import com.willfp.eco.core.items.TestableItem
 import com.willfp.eco.core.items.provider.ItemProvider
 import com.willfp.eco.util.namespacedKeyOf
-import net.kyori.adventure.key.Key
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
-import org.bukkit.inventory.ItemStack
 
-@Suppress("OVERRIDE_DEPRECATION")
 class CustomItemsNexo(
     private val plugin: EcoPlugin
 ) : CustomItemsIntegration, Listener {
@@ -31,19 +27,6 @@ class CustomItemsNexo(
     @Suppress("UNUSED_PARAMETER")
     fun onItemRegister(event: NexoItemsLoadedEvent) {
         Items.registerItemProvider(NexoProvider())
-
-        NexoItems.registerUpdateCallback(
-            Key.key("eco:nexo_update"),
-            object : UpdateCallback {
-                override fun preUpdate(itemStack: ItemStack): ItemStack? {
-                    return null
-                }
-
-                override fun postUpdate(itemStack: ItemStack): ItemStack {
-                    return itemStack
-                }
-            }
-        )
     }
 
     private class NexoProvider : ItemProvider("nexo") {

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/integrations/customitems/CustomItemsNexo.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/integrations/customitems/CustomItemsNexo.kt
@@ -2,6 +2,7 @@ package com.willfp.eco.internal.spigot.integrations.customitems
 
 import com.nexomc.nexo.api.NexoItems
 import com.nexomc.nexo.api.events.NexoItemsLoadedEvent
+import com.nexomc.nexo.items.UpdateCallback
 import com.willfp.eco.core.EcoPlugin
 import com.willfp.eco.core.integrations.customitems.CustomItemsIntegration
 import com.willfp.eco.core.items.CustomItem
@@ -9,8 +10,10 @@ import com.willfp.eco.core.items.Items
 import com.willfp.eco.core.items.TestableItem
 import com.willfp.eco.core.items.provider.ItemProvider
 import com.willfp.eco.util.namespacedKeyOf
+import net.kyori.adventure.key.Key
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
+import org.bukkit.inventory.ItemStack
 
 class CustomItemsNexo(
     private val plugin: EcoPlugin
@@ -27,6 +30,26 @@ class CustomItemsNexo(
     @Suppress("UNUSED_PARAMETER")
     fun onItemRegister(event: NexoItemsLoadedEvent) {
         Items.registerItemProvider(NexoProvider())
+
+        NexoItems.registerUpdateCallback(
+            Key.key("eco:nexo_update"),
+            object : UpdateCallback {
+                override fun preUpdate(itemStack: ItemStack?): ItemStack? {
+                    val ecoArmorNamespacedKey = namespacedKeyOf("ecoarmor", "set")
+                    val ecoItemsNamespacedKey = namespacedKeyOf("ecoitems", "item")
+                    val keys = itemStack?.persistentDataContainer?.keys ?: return super.preUpdate(itemStack)
+
+                    if (
+                        keys.contains(ecoArmorNamespacedKey)
+                        || keys.contains(ecoItemsNamespacedKey)
+                    ) {
+                        return null
+                    }
+
+                    return super.preUpdate(itemStack)
+                }
+            }
+        )
     }
 
     private class NexoProvider : ItemProvider("nexo") {


### PR DESCRIPTION
Restores compatibility with Nexo's item updater.

Previously, Eco registered its own Nexo item update callback and overrode preUpdate to always return null, which effectively broke Nexo's item updater.

This PR removes the unnecessary Nexo item update callback registration from Eco, allowing Nexo's item updater to function as intended again.