### PR TITLE
fix: ItemsAdder recipe issues

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/recipes/listeners/ComplexInVanilla.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/recipes/listeners/ComplexInVanilla.kt
@@ -6,6 +6,11 @@ import com.willfp.eco.internal.spigot.recipes.CraftingRecipeListener
 import com.willfp.eco.internal.spigot.recipes.GenericCraftEvent
 import com.willfp.eco.internal.spigot.recipes.RecipeListener
 import org.bukkit.Material
+import org.bukkit.NamespacedKey
+import org.bukkit.inventory.Recipe
+import org.bukkit.inventory.RecipeChoice
+import org.bukkit.inventory.ShapedRecipe
+import org.bukkit.inventory.ShapelessRecipe
 
 object ComplexInVanilla : RecipeListener {
     override fun handle(event: GenericCraftEvent) {
@@ -13,17 +18,46 @@ object ComplexInVanilla : RecipeListener {
             return
         }
 
+        // Recipes from other plugins ask for their own custom items on purpose, so
+        // only vanilla recipes (which match by material alone) need protecting.
+        if (event.recipe.key.namespace != NamespacedKey.MINECRAFT) {
+            return
+        }
+
         if (CraftingRecipeListener.validators.any { it.validate(event) }) {
             return
         }
 
+        val exactChoices = exactChoicesOf(event.recipe as? Recipe)
+
         for (itemStack in event.inventory.matrix) {
-            if (itemStack?.type == Material.SHIELD) {
+            val item = itemStack ?: continue
+
+            if (item.type == Material.SHIELD) {
                 continue
             }
-            if (Items.isCustomItem(itemStack)) {
-                event.deny()
+
+            if (!Items.isCustomItem(item)) {
+                continue
             }
+
+            // If the recipe explicitly asks for this exact item, it isn't being
+            // passed off as its base material, so let it through.
+            if (exactChoices.any { it.test(item) }) {
+                continue
+            }
+
+            event.deny()
         }
+    }
+
+    private fun exactChoicesOf(recipe: Recipe?): List<RecipeChoice.ExactChoice> {
+        val choices: Collection<RecipeChoice?> = when (recipe) {
+            is ShapedRecipe -> recipe.choiceMap.values
+            is ShapelessRecipe -> recipe.choiceList
+            else -> emptyList()
+        }
+
+        return choices.filterIsInstance<RecipeChoice.ExactChoice>()
     }
 }


### PR DESCRIPTION
@
`ComplexInVanilla` was denying any craft that contained a custom item, which broke recipes registered by other plugins (ItemsAdder in particular) that legitimately require their own custom items as ingredients.

Changes:
- Only apply the check to vanilla recipes (`minecraft` namespace). Recipes from other plugins ask for their own custom items on purpose, so they no longer get denied.
- When a recipe uses `RecipeChoice.ExactChoice` matching the ingredient, allow it through — the item is not being passed off as its base material.
- Minor restructure of the matrix loop to use early `continue` instead of nesting.
@