### PR TITLE
fix: armor swapping via hotbar [EcoHub-15]

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/EcoSpigotPlugin.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/EcoSpigotPlugin.kt
@@ -150,6 +150,7 @@ import com.willfp.eco.internal.spigot.eventlisteners.PlayerJumpListenersPaper
 import com.willfp.eco.internal.spigot.eventlisteners.PlayerJumpListenersSpigot
 import com.willfp.eco.internal.spigot.eventlisteners.armor.ArmorChangeEventListeners
 import com.willfp.eco.internal.spigot.eventlisteners.armor.ArmorListener
+import com.willfp.eco.internal.spigot.eventlisteners.armor.ArmorListenerPaper
 import com.willfp.eco.internal.spigot.gui.GUIListener
 import com.willfp.eco.internal.spigot.integrations.afk.AFKIntegrationCMI
 import com.willfp.eco.internal.spigot.integrations.afk.AFKIntegrationEssentials
@@ -593,6 +594,7 @@ abstract class EcoSpigotPlugin : EcoPlugin() {
         if (Prerequisite.HAS_PAPER.isMet) {
             listeners.add(PlayerJumpListenersPaper())
             listeners.add(NaturalExpGainListenersPaper())
+            listeners.add(ArmorListenerPaper())
         } else {
             listeners.add(PlayerJumpListenersSpigot())
             listeners.add(NaturalExpGainListenersSpigot())

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/eventlisteners/armor/ArmorChangeEventListeners.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/eventlisteners/armor/ArmorChangeEventListeners.kt
@@ -8,15 +8,27 @@ import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.block.BlockDispenseArmorEvent
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 
 class ArmorChangeEventListeners(
     private val plugin: EcoPlugin
 ) : Listener {
+    // A single action can produce several ArmorEquipEvents, which would otherwise each
+    // schedule an identical ArmorChangeEvent for the following tick.
+    private val pending = ConcurrentHashMap.newKeySet<UUID>()
+
     @EventHandler
     fun onArmorChange(event: ArmorEquipEvent) {
         val player = event.player
+
+        if (!pending.add(player.uniqueId)) {
+            return
+        }
+
         val before = player.inventory.armorContents.toMutableList()
         plugin.scheduler.run {
+            pending.remove(player.uniqueId)
             val after = player.inventory.armorContents.toMutableList()
             val armorChangeEvent = ArmorChangeEvent(player, before, after)
             Bukkit.getPluginManager().callEvent(armorChangeEvent)

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/eventlisteners/armor/ArmorListener.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/eventlisteners/armor/ArmorListener.kt
@@ -107,17 +107,12 @@ class ArmorListener : Listener {
             return
         }
         if (e.action == Action.RIGHT_CLICK_AIR || e.action == Action.RIGHT_CLICK_BLOCK) {
+            // Right-clicking armor equips it into an empty slot, and swaps it with the piece
+            // already worn if the slot is occupied, so the armor doesn't have to be air.
             val newArmorType = ArmorType.matchType(e.item)
             if (newArmorType != null) {
-                if (newArmorType == ArmorType.HELMET && isAirOrNull(e.player.inventory.helmet) || newArmorType == ArmorType.CHESTPLATE && isAirOrNull(
-                        e.player.inventory.chestplate
-                    ) || newArmorType == ArmorType.LEGGINGS && isAirOrNull(e.player.inventory.leggings) || newArmorType == ArmorType.BOOTS && isAirOrNull(
-                        e.player.inventory.boots
-                    )
-                ) {
-                    val armorEquipEvent = ArmorEquipEvent(e.player)
-                    Bukkit.getPluginManager().callEvent(armorEquipEvent)
-                }
+                val armorEquipEvent = ArmorEquipEvent(e.player)
+                Bukkit.getPluginManager().callEvent(armorEquipEvent)
             }
         }
     }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/eventlisteners/armor/ArmorListenerPaper.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/eventlisteners/armor/ArmorListenerPaper.kt
@@ -1,0 +1,18 @@
+package com.willfp.eco.internal.spigot.eventlisteners.armor
+
+import com.willfp.eco.core.events.ArmorEquipEvent
+import org.bukkit.Bukkit
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+
+/**
+ * Paper fires an event for every armor slot mutation, so it catches the changes that the
+ * heuristics in [ArmorListener] miss, such as swapping out a piece that's already worn.
+ */
+class ArmorListenerPaper : Listener {
+    @EventHandler(priority = EventPriority.MONITOR)
+    fun onArmorChange(event: com.destroystokyo.paper.event.player.PlayerArmorChangeEvent) {
+        Bukkit.getPluginManager().callEvent(ArmorEquipEvent(event.player))
+    }
+}

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/eventlisteners/armor/ArmorListenerPaper.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/eventlisteners/armor/ArmorListenerPaper.kt
@@ -1,5 +1,6 @@
 package com.willfp.eco.internal.spigot.eventlisteners.armor
 
+import com.destroystokyo.paper.event.player.PlayerArmorChangeEvent
 import com.willfp.eco.core.events.ArmorEquipEvent
 import org.bukkit.Bukkit
 import org.bukkit.event.EventHandler
@@ -12,7 +13,7 @@ import org.bukkit.event.Listener
  */
 class ArmorListenerPaper : Listener {
     @EventHandler(priority = EventPriority.MONITOR)
-    fun onArmorChange(event: com.destroystokyo.paper.event.player.PlayerArmorChangeEvent) {
+    fun onArmorChange(event: PlayerArmorChangeEvent) {
         Bukkit.getPluginManager().callEvent(ArmorEquipEvent(event.player))
     }
 }


### PR DESCRIPTION
## Description

Fixed armor swapping mechanism.

### QA
```
  ┌───────────────────────────────┬────────────────────────────────────────┬──────────────────────────┐
  │             File              │               Condition                │  Potion (visual proof)   │
  ├───────────────────────────────┼────────────────────────────────────────┼──────────────────────────┤
  │ test_helmet_diamond.yml       │ wearing_helmet: diamond_helmet         │ GLOWING                  │
  ├───────────────────────────────┼────────────────────────────────────────┼──────────────────────────┤
  │ test_helmet_iron.yml          │ wearing_helmet: iron_helmet            │ NIGHT_VISION             │
  ├───────────────────────────────┼────────────────────────────────────────┼──────────────────────────┤
  │ test_chestplate.yml           │ wearing_chestplate: diamond_chestplate │ SPEED III                │
  ├───────────────────────────────┼────────────────────────────────────────┼──────────────────────────┤
  │ test_leggings.yml             │ wearing_leggings: diamond_leggings     │ SATURATION               │
  ├───────────────────────────────┼────────────────────────────────────────┼──────────────────────────┤
  │ test_boots.yml                │ wearing_boots: diamond_boots           │ WATER_BREATHING          │
  ├───────────────────────────────┼────────────────────────────────────────┼──────────────────────────┤
  │ test_mainhand.yml             │ in_mainhand: diamond_sword             │ GLOWING                  │
  ├───────────────────────────────┼────────────────────────────────────────┼──────────────────────────┤
  │ test_offhand.yml              │ in_offhand: shield                     │ NIGHT_VISION             │
  ├───────────────────────────────┼────────────────────────────────────────┼──────────────────────────┤
  │ test_change_armor_trigger.yml │ none (always active)                   │ — (reports change_armor) │
  └───────────────────────────────┴────────────────────────────────────────┴──────────────────────────┘
  ```