### PR TITLE
feat: added virtual GUI methods [EcoHub-16]

### DIFF
--- a/eco-api/src/main/java/com/willfp/eco/core/Eco.java
+++ b/eco-api/src/main/java/com/willfp/eco/core/Eco.java
@@ -25,6 +25,9 @@ import com.willfp.eco.core.gui.menu.MenuBuilder;
 import com.willfp.eco.core.gui.menu.MenuType;
 import com.willfp.eco.core.gui.slot.SlotBuilder;
 import com.willfp.eco.core.gui.slot.functional.SlotProvider;
+import com.willfp.eco.core.gui.view.LocationViewBuilder;
+import com.willfp.eco.core.gui.view.MerchantViewBuilder;
+import com.willfp.eco.core.gui.view.ViewBuilder;
 import com.willfp.eco.core.integrations.hologram.Hologram;
 import com.willfp.eco.core.integrations.hologram.HologramOptions;
 import com.willfp.eco.core.items.TestableItem;
@@ -46,8 +49,12 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Mob;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Recipe;
+import org.bukkit.inventory.view.MerchantView;
+import org.bukkit.inventory.view.builder.InventoryViewBuilder;
+import org.bukkit.inventory.view.builder.LocationInventoryViewBuilder;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.jetbrains.annotations.ApiStatus;
@@ -317,6 +324,38 @@ public interface Eco {
     @NotNull
     Menu blendMenuState(@NotNull Menu base,
                         @NotNull Menu additional);
+
+    /**
+     * Create a view builder.
+     *
+     * @param type The menu type.
+     * @param <V>  The type of view created by the builder.
+     * @return The builder.
+     */
+    @NotNull
+    <V extends InventoryView> ViewBuilder<V> createViewBuilder(
+            @NotNull org.bukkit.inventory.MenuType.Typed<V, ? extends InventoryViewBuilder<V>> type
+    );
+
+    /**
+     * Create a view builder for a menu type backed by a block in the world.
+     *
+     * @param type The menu type.
+     * @param <V>  The type of view created by the builder.
+     * @return The builder.
+     */
+    @NotNull
+    <V extends InventoryView> LocationViewBuilder<V> createLocationViewBuilder(
+            @NotNull org.bukkit.inventory.MenuType.Typed<V, LocationInventoryViewBuilder<V>> type
+    );
+
+    /**
+     * Create a view builder for the merchant (villager trading) menu type.
+     *
+     * @return The builder.
+     */
+    @NotNull
+    MerchantViewBuilder<MerchantView> createMerchantViewBuilder();
 
     /**
      * Clean up ClassLoader (etc.) to allow PlugMan support.

--- a/eco-api/src/main/java/com/willfp/eco/core/gui/view/LocationViewBuilder.java
+++ b/eco-api/src/main/java/com/willfp/eco/core/gui/view/LocationViewBuilder.java
@@ -28,14 +28,14 @@ public interface LocationViewBuilder<V extends InventoryView> extends ViewBuilde
      * Set the location backing the view.
      * <p>
      * The block at the location does not have to match the type of the view; if it doesn't,
-     * the view still behaves as its own type. If no location is set, a virtual view is
-     * created instead.
+     * the view still behaves as its own type. Leave this unset to create a virtual view -
+     * there is no way to unset a location once given.
      *
-     * @param location The location, or null for a virtual view.
+     * @param location The location.
      * @return This builder.
      */
     @NotNull
-    LocationViewBuilder<V> location(@Nullable Location location);
+    LocationViewBuilder<V> location(@NotNull Location location);
 
     /**
      * Set whether the server should check that the player can reach the location.

--- a/eco-api/src/main/java/com/willfp/eco/core/gui/view/LocationViewBuilder.java
+++ b/eco-api/src/main/java/com/willfp/eco/core/gui/view/LocationViewBuilder.java
@@ -1,0 +1,50 @@
+package com.willfp.eco.core.gui.view;
+
+import org.bukkit.Location;
+import org.bukkit.inventory.InventoryView;
+import org.bukkit.inventory.view.builder.LocationInventoryViewBuilder;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Server-software-agnostic wrapper around {@link LocationInventoryViewBuilder}.
+ * <p>
+ * Used for views that are backed by a block in the world, such as anvils, furnaces,
+ * and enchantment tables.
+ *
+ * @param <V> The type of view created by this builder.
+ * @see ViewBuilders#location(org.bukkit.inventory.MenuType.Typed)
+ */
+public interface LocationViewBuilder<V extends InventoryView> extends ViewBuilder<V> {
+    @Override
+    @NotNull
+    LocationViewBuilder<V> title(@Nullable String title);
+
+    @Override
+    @NotNull
+    LocationViewBuilder<V> copy();
+
+    /**
+     * Set the location backing the view.
+     * <p>
+     * The block at the location does not have to match the type of the view; if it doesn't,
+     * the view still behaves as its own type. If no location is set, a virtual view is
+     * created instead.
+     *
+     * @param location The location, or null for a virtual view.
+     * @return This builder.
+     */
+    @NotNull
+    LocationViewBuilder<V> location(@Nullable Location location);
+
+    /**
+     * Set whether the server should check that the player can reach the location.
+     * <p>
+     * Has no effect on a virtual view (one with no location set).
+     *
+     * @param checkReachable Whether to check that the view is reachable.
+     * @return This builder.
+     */
+    @NotNull
+    LocationViewBuilder<V> checkReachable(boolean checkReachable);
+}

--- a/eco-api/src/main/java/com/willfp/eco/core/gui/view/MerchantViewBuilder.java
+++ b/eco-api/src/main/java/com/willfp/eco/core/gui/view/MerchantViewBuilder.java
@@ -1,0 +1,47 @@
+package com.willfp.eco.core.gui.view;
+
+import org.bukkit.inventory.InventoryView;
+import org.bukkit.inventory.Merchant;
+import org.bukkit.inventory.view.builder.MerchantInventoryViewBuilder;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Server-software-agnostic wrapper around {@link MerchantInventoryViewBuilder}.
+ * <p>
+ * Opens a trading screen for a {@link Merchant}, which does not have to be a villager -
+ * a virtual merchant from {@link org.bukkit.Bukkit#createMerchant()} works too, so trades
+ * can be offered without any entity existing.
+ *
+ * @param <V> The type of view created by this builder.
+ * @see ViewBuilders#merchant()
+ */
+public interface MerchantViewBuilder<V extends InventoryView> extends ViewBuilder<V> {
+    @Override
+    @NotNull
+    MerchantViewBuilder<V> title(@Nullable String title);
+
+    @Override
+    @NotNull
+    MerchantViewBuilder<V> copy();
+
+    /**
+     * Set the merchant the view trades with.
+     *
+     * @param merchant The merchant.
+     * @return This builder.
+     */
+    @NotNull
+    MerchantViewBuilder<V> merchant(@NotNull Merchant merchant);
+
+    /**
+     * Set whether the server should check that the player can reach the merchant.
+     * <p>
+     * Has no effect on a virtual merchant.
+     *
+     * @param checkReachable Whether to check that the view is reachable.
+     * @return This builder.
+     */
+    @NotNull
+    MerchantViewBuilder<V> checkReachable(boolean checkReachable);
+}

--- a/eco-api/src/main/java/com/willfp/eco/core/gui/view/ViewBuilder.java
+++ b/eco-api/src/main/java/com/willfp/eco/core/gui/view/ViewBuilder.java
@@ -1,0 +1,63 @@
+package com.willfp.eco.core.gui.view;
+
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.inventory.InventoryView;
+import org.bukkit.inventory.view.builder.InventoryViewBuilder;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Server-software-agnostic wrapper around {@link InventoryViewBuilder}.
+ * <p>
+ * Bukkit's own builders take the view title in a type that differs between server
+ * implementations - Spigot takes a legacy {@link String}, Paper takes an Adventure
+ * {@code Component} - so code compiled against one fails at runtime on the other.
+ * This builder takes a legacy-formatted string on every platform and converts it
+ * to whatever the running server expects.
+ *
+ * @param <V> The type of view created by this builder.
+ * @see ViewBuilders
+ */
+public interface ViewBuilder<V extends InventoryView> {
+    /**
+     * Set the title of the view.
+     *
+     * @param title The title, legacy-formatted (e.g. {@code "&8Trades"}), or null for the default title.
+     * @return This builder.
+     */
+    @NotNull
+    ViewBuilder<V> title(@Nullable String title);
+
+    /**
+     * Build the view.
+     * <p>
+     * Building does not show the view to the player; pass it to
+     * {@link HumanEntity#openInventory(InventoryView)} to do that, or use {@link #open(HumanEntity)}.
+     *
+     * @param player The player to build the view for.
+     * @return The view.
+     */
+    @NotNull
+    V build(@NotNull HumanEntity player);
+
+    /**
+     * Build the view and open it for the player.
+     *
+     * @param player The player to open the view for.
+     * @return The view that was opened.
+     */
+    @NotNull
+    default V open(@NotNull HumanEntity player) {
+        V view = this.build(player);
+        player.openInventory(view);
+        return view;
+    }
+
+    /**
+     * Make a copy of this builder.
+     *
+     * @return The copy.
+     */
+    @NotNull
+    ViewBuilder<V> copy();
+}

--- a/eco-api/src/main/java/com/willfp/eco/core/gui/view/ViewBuilders.java
+++ b/eco-api/src/main/java/com/willfp/eco/core/gui/view/ViewBuilders.java
@@ -1,0 +1,65 @@
+package com.willfp.eco.core.gui.view;
+
+import com.willfp.eco.core.Eco;
+import org.bukkit.inventory.InventoryView;
+import org.bukkit.inventory.MenuType;
+import org.bukkit.inventory.view.MerchantView;
+import org.bukkit.inventory.view.builder.InventoryViewBuilder;
+import org.bukkit.inventory.view.builder.LocationInventoryViewBuilder;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Create {@link ViewBuilder}s: server-software-agnostic versions of Bukkit's
+ * {@link InventoryViewBuilder}s.
+ * <p>
+ * Use these instead of {@link MenuType.Typed#builder()} directly - the Bukkit builders
+ * take their title in a different type on Spigot than on Paper, so calling them from a
+ * plugin compiled against one fails at runtime on the other.
+ * <p>
+ * These builders are for vanilla-backed views (anvils, merchants, and the like).
+ * For a regular chest-style GUI, use {@link com.willfp.eco.core.gui.menu.Menu}.
+ */
+public final class ViewBuilders {
+    /**
+     * Create a builder for any menu type.
+     *
+     * @param type The menu type.
+     * @param <V>  The type of view created by the builder.
+     * @return The builder.
+     */
+    @NotNull
+    public static <V extends InventoryView> ViewBuilder<V> of(
+            @NotNull final MenuType.Typed<V, ? extends InventoryViewBuilder<V>> type
+    ) {
+        return Eco.get().createViewBuilder(type);
+    }
+
+    /**
+     * Create a builder for a menu type backed by a block in the world, for example
+     * {@link MenuType#ANVIL} or {@link MenuType#ENCHANTMENT}.
+     *
+     * @param type The menu type.
+     * @param <V>  The type of view created by the builder.
+     * @return The builder.
+     */
+    @NotNull
+    public static <V extends InventoryView> LocationViewBuilder<V> location(
+            @NotNull final MenuType.Typed<V, LocationInventoryViewBuilder<V>> type
+    ) {
+        return Eco.get().createLocationViewBuilder(type);
+    }
+
+    /**
+     * Create a builder for {@link MenuType#MERCHANT}, the villager trading screen.
+     *
+     * @return The builder.
+     */
+    @NotNull
+    public static MerchantViewBuilder<MerchantView> merchant() {
+        return Eco.get().createMerchantViewBuilder();
+    }
+
+    private ViewBuilders() {
+        throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
+    }
+}

--- a/eco-core/core-backend/src/main/kotlin/com/willfp/eco/internal/gui/view/EcoViewBuilder.kt
+++ b/eco-core/core-backend/src/main/kotlin/com/willfp/eco/internal/gui/view/EcoViewBuilder.kt
@@ -23,7 +23,7 @@ open class EcoViewBuilder<V : InventoryView, B : InventoryViewBuilder<V>>(
     override fun build(player: HumanEntity): V = handle.build(player)
 
     @Suppress("UNCHECKED_CAST")
-    override fun copy(): ViewBuilder<V> = EcoViewBuilder(handle.copy() as B)
+    override fun copy(): ViewBuilder<V> = EcoViewBuilder<V, B>(handle.copy() as B)
 }
 
 class EcoLocationViewBuilder<V : InventoryView>(
@@ -33,7 +33,7 @@ class EcoLocationViewBuilder<V : InventoryView>(
         handle = ViewTitles.apply(handle, title)
     }
 
-    override fun location(location: Location?): LocationViewBuilder<V> = apply {
+    override fun location(location: Location): LocationViewBuilder<V> = apply {
         handle = handle.location(location)
     }
 

--- a/eco-core/core-backend/src/main/kotlin/com/willfp/eco/internal/gui/view/EcoViewBuilder.kt
+++ b/eco-core/core-backend/src/main/kotlin/com/willfp/eco/internal/gui/view/EcoViewBuilder.kt
@@ -1,0 +1,63 @@
+package com.willfp.eco.internal.gui.view
+
+import com.willfp.eco.core.gui.view.LocationViewBuilder
+import com.willfp.eco.core.gui.view.MerchantViewBuilder
+import com.willfp.eco.core.gui.view.ViewBuilder
+import org.bukkit.Location
+import org.bukkit.entity.HumanEntity
+import org.bukkit.inventory.InventoryView
+import org.bukkit.inventory.Merchant
+import org.bukkit.inventory.view.builder.InventoryViewBuilder
+import org.bukkit.inventory.view.builder.LocationInventoryViewBuilder
+import org.bukkit.inventory.view.builder.MerchantInventoryViewBuilder
+
+// Thin wrappers over Bukkit's builders. The only behaviour here is routing the title through
+// ViewTitles, which is the one call that differs between server software.
+open class EcoViewBuilder<V : InventoryView, B : InventoryViewBuilder<V>>(
+    protected var handle: B
+) : ViewBuilder<V> {
+    override fun title(title: String?): ViewBuilder<V> = apply {
+        handle = ViewTitles.apply(handle, title)
+    }
+
+    override fun build(player: HumanEntity): V = handle.build(player)
+
+    @Suppress("UNCHECKED_CAST")
+    override fun copy(): ViewBuilder<V> = EcoViewBuilder(handle.copy() as B)
+}
+
+class EcoLocationViewBuilder<V : InventoryView>(
+    handle: LocationInventoryViewBuilder<V>
+) : EcoViewBuilder<V, LocationInventoryViewBuilder<V>>(handle), LocationViewBuilder<V> {
+    override fun title(title: String?): LocationViewBuilder<V> = apply {
+        handle = ViewTitles.apply(handle, title)
+    }
+
+    override fun location(location: Location?): LocationViewBuilder<V> = apply {
+        handle = handle.location(location)
+    }
+
+    override fun checkReachable(checkReachable: Boolean): LocationViewBuilder<V> = apply {
+        handle = handle.checkReachable(checkReachable)
+    }
+
+    override fun copy(): LocationViewBuilder<V> = EcoLocationViewBuilder(handle.copy())
+}
+
+class EcoMerchantViewBuilder<V : InventoryView>(
+    handle: MerchantInventoryViewBuilder<V>
+) : EcoViewBuilder<V, MerchantInventoryViewBuilder<V>>(handle), MerchantViewBuilder<V> {
+    override fun title(title: String?): MerchantViewBuilder<V> = apply {
+        handle = ViewTitles.apply(handle, title)
+    }
+
+    override fun merchant(merchant: Merchant): MerchantViewBuilder<V> = apply {
+        handle = handle.merchant(merchant)
+    }
+
+    override fun checkReachable(checkReachable: Boolean): MerchantViewBuilder<V> = apply {
+        handle = handle.checkReachable(checkReachable)
+    }
+
+    override fun copy(): MerchantViewBuilder<V> = EcoMerchantViewBuilder(handle.copy())
+}

--- a/eco-core/core-backend/src/main/kotlin/com/willfp/eco/internal/gui/view/ViewTitles.kt
+++ b/eco-core/core-backend/src/main/kotlin/com/willfp/eco/internal/gui/view/ViewTitles.kt
@@ -1,0 +1,35 @@
+package com.willfp.eco.internal.gui.view
+
+import com.willfp.eco.core.Prerequisite
+import com.willfp.eco.util.toComponent
+import org.bukkit.inventory.view.builder.InventoryViewBuilder
+import java.lang.reflect.Method
+
+internal interface ViewTitle {
+    fun apply(handle: InventoryViewBuilder<*>, title: String): InventoryViewBuilder<*>
+}
+
+private object PaperViewTitle : ViewTitle {
+    override fun apply(handle: InventoryViewBuilder<*>, title: String): InventoryViewBuilder<*> =
+        handle.title(title.toComponent())
+}
+
+private object SpigotViewTitle : ViewTitle {
+    // Resolved against the interface rather than the CraftBukkit implementation class, which
+    // isn't public and so can't be invoked reflectively.
+    private val method: Method by lazy {
+        InventoryViewBuilder::class.java.getMethod("title", String::class.java)
+    }
+
+    override fun apply(handle: InventoryViewBuilder<*>, title: String): InventoryViewBuilder<*> =
+        method.invoke(handle, title) as InventoryViewBuilder<*>
+}
+
+internal object ViewTitles {
+    private val impl: ViewTitle =
+        if (Prerequisite.HAS_PAPER.isMet) PaperViewTitle else SpigotViewTitle
+
+    @Suppress("UNCHECKED_CAST")
+    fun <B : InventoryViewBuilder<*>> apply(handle: B, title: String?): B =
+        if (title == null) handle else impl.apply(handle, title) as B
+}

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/EcoImpl.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/EcoImpl.kt
@@ -259,7 +259,7 @@ class EcoImpl : EcoSpigotPlugin(), Eco {
 
     override fun <V : InventoryView> createViewBuilder(
         type: BukkitMenuType.Typed<V, out InventoryViewBuilder<V>>
-    ): ViewBuilder<V> = EcoViewBuilder(type.builder())
+    ): ViewBuilder<V> = EcoViewBuilder<V, InventoryViewBuilder<V>>(type.builder())
 
     override fun <V : InventoryView> createLocationViewBuilder(
         type: BukkitMenuType.Typed<V, LocationInventoryViewBuilder<V>>

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/EcoImpl.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/EcoImpl.kt
@@ -22,6 +22,9 @@ import com.willfp.eco.core.data.keys.PersistentDataKey
 import com.willfp.eco.core.gui.menu.Menu
 import com.willfp.eco.core.gui.menu.MenuType
 import com.willfp.eco.core.gui.slot.functional.SlotProvider
+import com.willfp.eco.core.gui.view.LocationViewBuilder
+import com.willfp.eco.core.gui.view.MerchantViewBuilder
+import com.willfp.eco.core.gui.view.ViewBuilder
 import com.willfp.eco.core.items.Items
 import com.willfp.eco.core.packet.Packet
 import com.willfp.eco.core.placeholder.context.PlaceholderContext
@@ -45,6 +48,9 @@ import com.willfp.eco.internal.gui.MergedStateMenu
 import com.willfp.eco.internal.gui.menu.EcoMenuBuilder
 import com.willfp.eco.internal.gui.menu.renderedInventory
 import com.willfp.eco.internal.gui.slot.EcoSlotBuilder
+import com.willfp.eco.internal.gui.view.EcoLocationViewBuilder
+import com.willfp.eco.internal.gui.view.EcoMerchantViewBuilder
+import com.willfp.eco.internal.gui.view.EcoViewBuilder
 import com.willfp.eco.internal.integrations.PAPIExpansion
 import com.willfp.eco.internal.logging.EcoLogger
 import com.willfp.eco.internal.logging.NOOPLogger
@@ -80,8 +86,13 @@ import org.bukkit.entity.Entity
 import org.bukkit.entity.LivingEntity
 import org.bukkit.entity.Mob
 import org.bukkit.entity.Player
+import org.bukkit.inventory.InventoryView
 import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.Recipe
+import org.bukkit.inventory.view.MerchantView
+import org.bukkit.inventory.view.builder.InventoryViewBuilder
+import org.bukkit.inventory.view.builder.LocationInventoryViewBuilder
+import org.bukkit.inventory.MenuType as BukkitMenuType
 import org.bukkit.inventory.meta.SkullMeta
 import org.bukkit.persistence.PersistentDataContainer
 
@@ -245,6 +256,17 @@ class EcoImpl : EcoSpigotPlugin(), Eco {
 
     override fun blendMenuState(base: Menu, additional: Menu) =
         MergedStateMenu(base, additional)
+
+    override fun <V : InventoryView> createViewBuilder(
+        type: BukkitMenuType.Typed<V, out InventoryViewBuilder<V>>
+    ): ViewBuilder<V> = EcoViewBuilder(type.builder())
+
+    override fun <V : InventoryView> createLocationViewBuilder(
+        type: BukkitMenuType.Typed<V, LocationInventoryViewBuilder<V>>
+    ): LocationViewBuilder<V> = EcoLocationViewBuilder(type.builder())
+
+    override fun createMerchantViewBuilder(): MerchantViewBuilder<MerchantView> =
+        EcoMerchantViewBuilder(BukkitMenuType.MERCHANT.builder())
 
     override fun clean(plugin: EcoPlugin) {
         // Prevent self-cleaning

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/recipes/workstation/WorkstationRecipeListener.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/recipes/workstation/WorkstationRecipeListener.kt
@@ -131,7 +131,7 @@ class WorkstationRecipeListener(private val plugin: EcoPlugin) : Listener {
                         if (villagerRecipe.minLevel > 0 && villager.villagerLevel < villagerRecipe.minLevel) return@filter false
                     }
                 }
-                val pdcKey = NamespacedKey("recipebook", "vr_${villagerRecipe.key.key}")
+                val pdcKey = NamespacedKey("ecocrafting", "vr_${villagerRecipe.key.key}")
                 val pdc = merchant.persistentDataContainer
                 if (pdc.has(pdcKey, PersistentDataType.BYTE)) {
                     pdc.get(pdcKey, PersistentDataType.BYTE) == 1.toByte()

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/recipes/workstation/WorkstationRecipeListener.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/recipes/workstation/WorkstationRecipeListener.kt
@@ -112,6 +112,23 @@ class WorkstationRecipeListener(private val plugin: EcoPlugin) : Listener {
 
     // Villager / merchant
 
+    // These rolls used to be stored under a "recipebook" namespace, which nothing else in eco
+    // or EcoCrafting looked at - EcoCrafting's stale-key cleanup scans "ecocrafting", so the old
+    // entries were never pruned. Move a villager's existing roll over the first time it's opened
+    // so trades that were already decided stay decided, rather than being re-rolled.
+    private fun migrateLegacyTradeKey(
+        pdc: org.bukkit.persistence.PersistentDataContainer,
+        recipeKey: String,
+        newKey: NamespacedKey
+    ) {
+        val legacyKey = NamespacedKey("recipebook", "vr_$recipeKey")
+        if (!pdc.has(legacyKey, PersistentDataType.BYTE)) return
+        if (!pdc.has(newKey, PersistentDataType.BYTE)) {
+            pdc.get(legacyKey, PersistentDataType.BYTE)?.let { pdc.set(newKey, PersistentDataType.BYTE, it) }
+        }
+        pdc.remove(legacyKey)
+    }
+
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     fun onMerchantOpen(event: InventoryOpenEvent) {
         if (event.inventory.type != InventoryType.MERCHANT) return
@@ -121,6 +138,11 @@ class WorkstationRecipeListener(private val plugin: EcoPlugin) : Listener {
 
         val filteredRecipes = WorkstationRecipes.getAll(VillagerRecipe::class.java)
             .filter { villagerRecipe ->
+                migrateLegacyTradeKey(
+                    merchant.persistentDataContainer,
+                    villagerRecipe.key.key,
+                    NamespacedKey("ecocrafting", "vr_${villagerRecipe.key.key}")
+                )
                 if (isWanderingTrader) {
                     if (!villagerRecipe.isWanderingTrader) return@filter false
                 } else {


### PR DESCRIPTION
## Description

- Fixes issue with PDC namespace utilised in Eco versus EcoCrafting
- Adds new API shim for [`InventoryViewBuilder`](https://jd.papermc.io/paper/26.2/org/bukkit/inventory/view/builder/InventoryViewBuilder.html).
- Adds migration from old PDC (`recipebook`) to new PDC namespace (`ecocrafting`) - keep for a while to catch all stragglers.