### PR TITLE
feat: added PlayerProfileResolver to allow plugins to store player data against a different UUID

### DIFF
--- a/eco-api/src/main/java/com/willfp/eco/core/Eco.java
+++ b/eco-api/src/main/java/com/willfp/eco/core/Eco.java
@@ -10,6 +10,7 @@ import com.willfp.eco.core.config.interfaces.LoadableConfig;
 import com.willfp.eco.core.config.updating.ConfigHandler;
 import com.willfp.eco.core.data.ExtendedPersistentDataContainer;
 import com.willfp.eco.core.data.PlayerProfile;
+import com.willfp.eco.core.data.PlayerProfileResolver;
 import com.willfp.eco.core.data.ServerProfile;
 import com.willfp.eco.core.data.keys.PersistentDataKey;
 import com.willfp.eco.core.datapack.DatapackContributor;
@@ -458,6 +459,21 @@ public interface Eco {
      */
     @NotNull
     ServerProfile getServerProfile();
+
+    /**
+     * Set the resolver used to decide which UUID a player's data is stored against.
+     *
+     * @param resolver The resolver, or null to store data against the player's own UUID.
+     */
+    void setPlayerProfileResolver(@Nullable PlayerProfileResolver resolver);
+
+    /**
+     * Get the resolver used to decide which UUID a player's data is stored against.
+     *
+     * @return The resolver, resolving to the player's own UUID if none has been set.
+     */
+    @NotNull
+    PlayerProfileResolver getPlayerProfileResolver();
 
     /**
      * Create dummy entity - never spawned, exists purely in code.

--- a/eco-api/src/main/java/com/willfp/eco/core/data/PlayerProfile.java
+++ b/eco-api/src/main/java/com/willfp/eco/core/data/PlayerProfile.java
@@ -21,7 +21,7 @@ public interface PlayerProfile extends Profile {
      */
     @NotNull
     static PlayerProfile load(@NotNull final OfflinePlayer player) {
-        return load(player.getUniqueId());
+        return load(Eco.get().getPlayerProfileResolver().resolve(player));
     }
 
     /**

--- a/eco-api/src/main/java/com/willfp/eco/core/data/PlayerProfileResolver.java
+++ b/eco-api/src/main/java/com/willfp/eco/core/data/PlayerProfileResolver.java
@@ -1,0 +1,24 @@
+package com.willfp.eco.core.data;
+
+import org.bukkit.OfflinePlayer;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
+
+/**
+ * Resolves the UUID that a player's persistent data is stored against.
+ * <p>
+ * Only {@link PlayerProfile#load(OfflinePlayer)} uses the resolver, so
+ * {@link PlayerProfile#load(UUID)} can still be used to reach a player's own data.
+ */
+@FunctionalInterface
+public interface PlayerProfileResolver {
+    /**
+     * Resolve the UUID for a player.
+     *
+     * @param player The player.
+     * @return The UUID.
+     */
+    @NotNull
+    UUID resolve(@NotNull OfflinePlayer player);
+}

--- a/eco-api/src/main/java/com/willfp/eco/util/PlayerUtils.java
+++ b/eco-api/src/main/java/com/willfp/eco/util/PlayerUtils.java
@@ -110,7 +110,7 @@ public final class PlayerUtils {
             updateSavedDisplayName(onlinePlayer);
         }
 
-        PlayerProfile profile = PlayerProfile.load(player);
+        PlayerProfile profile = PlayerProfile.load(player.getUniqueId());
 
         String saved = profile.read(PLAYER_DISPLAY_NAME_KEY);
 
@@ -127,7 +127,7 @@ public final class PlayerUtils {
      * @param player The player.
      */
     public static void updateSavedDisplayName(@NotNull final Player player) {
-        PlayerProfile profile = PlayerProfile.load(player);
+        PlayerProfile profile = PlayerProfile.load(player.getUniqueId());
         profile.write(PLAYER_DISPLAY_NAME_KEY, player.getDisplayName());
     }
 
@@ -144,7 +144,7 @@ public final class PlayerUtils {
             updateSavedName(onlinePlayer);
         }
 
-        PlayerProfile profile = PlayerProfile.load(player);
+        PlayerProfile profile = PlayerProfile.load(player.getUniqueId());
 
         String saved = profile.read(PLAYER_NAME_KEY);
 
@@ -161,7 +161,7 @@ public final class PlayerUtils {
      * @param player The player.
      */
     public static void updateSavedName(@NotNull final Player player) {
-        PlayerProfile profile = PlayerProfile.load(player);
+        PlayerProfile profile = PlayerProfile.load(player.getUniqueId());
         profile.write(PLAYER_NAME_KEY, player.getName());
     }
 
@@ -175,7 +175,7 @@ public final class PlayerUtils {
      * @return The saved health in half-hearts, or 20.0 if none has been saved.
      */
     public static double getSavedHealth(@NotNull final OfflinePlayer player) {
-        PlayerProfile profile = PlayerProfile.load(player);
+        PlayerProfile profile = PlayerProfile.load(player.getUniqueId());
 
         return profile.read(PLAYER_HEALTH_KEY);
     }
@@ -186,7 +186,7 @@ public final class PlayerUtils {
      * @param player The player.
      */
     public static void saveHealth(@NotNull final Player player) {
-        PlayerProfile profile = PlayerProfile.load(player);
+        PlayerProfile profile = PlayerProfile.load(player.getUniqueId());
         profile.write(PLAYER_HEALTH_KEY, player.getHealth());
     }
 

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/EcoImpl.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/EcoImpl.kt
@@ -101,6 +101,7 @@ import org.bukkit.inventory.meta.SkullMeta
 import org.bukkit.persistence.PersistentDataContainer
 
 private val loadedEcoPlugins = mutableMapOf<String, EcoPlugin>()
+private val DEFAULT_PROFILE_RESOLVER = PlayerProfileResolver { it.uniqueId }
 
 @Suppress("UNUSED")
 class EcoImpl : EcoSpigotPlugin(), Eco {
@@ -338,10 +339,21 @@ class EcoImpl : EcoSpigotPlugin(), Eco {
     override fun loadPlayerProfile(uuid: UUID) =
         profileHandler.getPlayerProfile(uuid)
 
-    private var playerProfileResolver = PlayerProfileResolver { it.uniqueId }
+    // Read from whichever thread touches player data, so publication has to be guaranteed.
+    @Volatile
+    private var playerProfileResolver = DEFAULT_PROFILE_RESOLVER
 
     override fun setPlayerProfileResolver(resolver: PlayerProfileResolver?) {
-        playerProfileResolver = resolver ?: PlayerProfileResolver { it.uniqueId }
+        playerProfileResolver = if (resolver == null) DEFAULT_PROFILE_RESOLVER else {
+            // Wrapped rather than stored bare so every profile a player resolves to is recorded and
+            // can be unloaded when they leave. Only wrapped when a resolver is actually set, so the
+            // default path stays a plain UUID read.
+            PlayerProfileResolver { player ->
+                val profile = resolver.resolve(player)
+                profileHandler.trackResolvedProfile(player.uniqueId, profile)
+                profile
+            }
+        }
     }
 
     override fun getPlayerProfileResolver() = playerProfileResolver

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/EcoImpl.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/EcoImpl.kt
@@ -18,6 +18,7 @@ import com.willfp.eco.core.command.CommandBase
 import com.willfp.eco.core.command.PluginCommandBase
 import com.willfp.eco.core.config.ConfigType
 import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.eco.core.data.PlayerProfileResolver
 import com.willfp.eco.core.data.keys.PersistentDataKey
 import com.willfp.eco.core.datapack.DatapackContributor
 import com.willfp.eco.core.gui.menu.Menu
@@ -336,6 +337,14 @@ class EcoImpl : EcoSpigotPlugin(), Eco {
 
     override fun loadPlayerProfile(uuid: UUID) =
         profileHandler.getPlayerProfile(uuid)
+
+    private var playerProfileResolver = PlayerProfileResolver { it.uniqueId }
+
+    override fun setPlayerProfileResolver(resolver: PlayerProfileResolver?) {
+        playerProfileResolver = resolver ?: PlayerProfileResolver { it.uniqueId }
+    }
+
+    override fun getPlayerProfileResolver() = playerProfileResolver
 
     override fun createDummyEntity(location: Location): Entity =
         getProxy(DummyEntityFactoryProxy::class.java).createDummyEntity(location)

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/data/profiles/ProfileHandler.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/data/profiles/ProfileHandler.kt
@@ -31,6 +31,7 @@ class ProfileHandler(
     val profileWriter = ProfileWriter(plugin, this)
 
     private val loaded = ConcurrentHashMap<UUID, EcoProfile>()
+    private val resolvedProfiles = ConcurrentHashMap<UUID, MutableSet<UUID>>()
 
     fun getPlayerProfile(uuid: UUID): EcoPlayerProfile {
         return loaded.computeIfAbsent(uuid) {
@@ -46,6 +47,29 @@ class ProfileHandler(
 
     fun unloadProfile(uuid: UUID) {
         loaded.remove(uuid)
+    }
+
+    /**
+     * Record that a player's data resolved to [profile], so it can be unloaded when they leave.
+     *
+     * A player can resolve to several profiles over a session, and only the last one is reachable
+     * through the resolver by the time they quit - so the rest have to be remembered here or they
+     * stay in [loaded] for the lifetime of the server.
+     */
+    fun trackResolvedProfile(player: UUID, profile: UUID) {
+        if (player == profile) {
+            return
+        }
+
+        resolvedProfiles.computeIfAbsent(player) { ConcurrentHashMap.newKeySet() }.add(profile)
+    }
+
+    /**
+     * Unload a player's own profile along with every profile they resolved to.
+     */
+    fun unloadPlayer(player: UUID) {
+        loaded.remove(player)
+        resolvedProfiles.remove(player)?.forEach { loaded.remove(it) }
     }
 
     fun save() {

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/data/profiles/ProfileLoadListener.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/data/profiles/ProfileLoadListener.kt
@@ -1,5 +1,6 @@
 package com.willfp.eco.internal.spigot.data.profiles
 
+import com.willfp.eco.core.Eco
 import com.willfp.eco.core.EcoPlugin
 import com.willfp.eco.util.PlayerUtils
 import org.bukkit.event.EventHandler
@@ -16,11 +17,13 @@ class ProfileLoadListener(
     @EventHandler(priority = EventPriority.LOWEST)
     fun onLogin(event: PlayerLoginEvent) {
         handler.unloadProfile(event.player.uniqueId)
+        handler.unloadProfile(Eco.get().playerProfileResolver.resolve(event.player))
     }
 
     @EventHandler(priority = EventPriority.HIGHEST)
     fun onLeave(event: PlayerQuitEvent) {
         handler.unloadProfile(event.player.uniqueId)
+        handler.unloadProfile(Eco.get().playerProfileResolver.resolve(event.player))
     }
 
     @EventHandler

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/data/profiles/ProfileLoadListener.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/data/profiles/ProfileLoadListener.kt
@@ -1,6 +1,5 @@
 package com.willfp.eco.internal.spigot.data.profiles
 
-import com.willfp.eco.core.Eco
 import com.willfp.eco.core.EcoPlugin
 import com.willfp.eco.util.PlayerUtils
 import org.bukkit.event.EventHandler
@@ -16,14 +15,12 @@ class ProfileLoadListener(
 ) : Listener {
     @EventHandler(priority = EventPriority.LOWEST)
     fun onLogin(event: PlayerLoginEvent) {
-        handler.unloadProfile(event.player.uniqueId)
-        handler.unloadProfile(Eco.get().playerProfileResolver.resolve(event.player))
+        handler.unloadPlayer(event.player.uniqueId)
     }
 
     @EventHandler(priority = EventPriority.HIGHEST)
     fun onLeave(event: PlayerQuitEvent) {
-        handler.unloadProfile(event.player.uniqueId)
-        handler.unloadProfile(Eco.get().playerProfileResolver.resolve(event.player))
+        handler.unloadPlayer(event.player.uniqueId)
     }
 
     @EventHandler


### PR DESCRIPTION
I'm building a skyblock plugin with profile switching, where a player has separate saves that don't share skills, jobs, inventory or anything else.

Everything in eco is stored against the player's uuid, so all of a player's profiles share the same data. The only way I could work around it is copying every registered key to a different uuid on every switch, which is around 3,100 keys each way.

This adds a `PlayerProfileResolver` so a plugin can decide which uuid a player's data is stored against, and then nothing needs copying.

Only `PlayerProfile.load(OfflinePlayer)` goes through it. `load(UUID)` is unchanged, and `PlayerUtils` uses that for the saved name, display name and health so eco's own data placement isn't affected. It defaults to the player's own uuid, so nothing changes unless a plugin sets a resolver.

Tested on 2026.32 with about 40 plugins on their release jars. No difference with nothing registering a resolver, and proper per-profile data once my plugin registered one.

Not sure how you'd want it handled if two plugins both register a resolver - right now the last one wins.
