### PR TITLE
feat: validate datapack entries against the draft as well as the live registries

### DIFF
--- a/eco-core/core-nms/v1_21_8/src/main/kotlin/com/willfp/eco/internal/spigot/proxy/v1_21_8/DatapackCodec.kt
+++ b/eco-core/core-nms/v1_21_8/src/main/kotlin/com/willfp/eco/internal/spigot/proxy/v1_21_8/DatapackCodec.kt
@@ -5,8 +5,19 @@ import com.google.gson.JsonParser
 import com.mojang.serialization.DynamicOps
 import com.mojang.serialization.JsonOps
 import com.willfp.eco.internal.spigot.proxies.DatapackCodecProxy
+import com.willfp.eco.internal.spigot.proxies.PendingContent
+import java.util.Optional
+import net.minecraft.core.Holder
+import net.minecraft.core.HolderGetter
+import net.minecraft.core.HolderLookup
+import net.minecraft.core.HolderOwner
+import net.minecraft.core.HolderSet
+import net.minecraft.core.Registry
 import net.minecraft.core.registries.Registries
 import net.minecraft.resources.RegistryDataLoader
+import net.minecraft.resources.RegistryOps
+import net.minecraft.resources.ResourceKey
+import net.minecraft.tags.TagKey
 import org.bukkit.Bukkit
 import org.bukkit.craftbukkit.CraftServer
 
@@ -30,12 +41,12 @@ class DatapackCodec : DatapackCodecProxy {
 
     override fun validatableRegistries(): Set<String> = registries.keys
 
-    override fun validate(registryDirPath: String, json: String): String? {
+    override fun validate(registryDirPath: String, json: String, pending: PendingContent): String? {
         val data = registries[registryDirPath] ?: return null
 
         // Registry-aware ops, so that fields referencing other registry entries resolve instead of
         // failing as "can't parse without registry ops".
-        val ops = registryOps() ?: return null
+        val ops = registryOps(pending) ?: return null
 
         val element = try {
             JsonParser.parseString(json)
@@ -43,16 +54,122 @@ class DatapackCodec : DatapackCodecProxy {
             return e.message ?: "malformed JSON"
         }
 
-        return data.elementCodec()
-            .parse(ops, element)
-            .error()
-            .map { it.message() }
-            .orElse(null)
+        return try {
+            data.elementCodec()
+                .parse(ops, element)
+                .error()
+                .map { it.message() }
+                .orElse(null)
+        } catch (e: Throwable) {
+            /*
+            A placeholder holder for pending content is unbound: a codec that dereferences one
+            during decode, rather than merely resolving it, throws. Falling back to the syntax and
+            path tiers is weaker than a real decode, so it says so out loud rather than reporting a
+            clean pass.
+             */
+            if (pending.isEmpty()) "codec validation threw (${e.message})" else null
+        }
     }
 
-    private fun registryOps(): DynamicOps<JsonElement>? = runCatching {
-        (Bukkit.getServer() as CraftServer).server
+    private fun registryOps(pending: PendingContent): DynamicOps<JsonElement>? = runCatching {
+        val live = (Bukkit.getServer() as CraftServer).server
             .registryAccess()
             .createSerializationContext(JsonOps.INSTANCE)
+
+        if (pending.isEmpty()) {
+            live
+        } else {
+            RegistryOps.create(JsonOps.INSTANCE, DraftAwareLookup(live.lookupProvider, pending))
+        }
     }.getOrNull()
+
+    /**
+     * Wraps the live registry lookup so that references to content the same publish is writing
+     * resolve to a placeholder instead of an error.
+     */
+    private class DraftAwareLookup(
+        private val delegate: RegistryOps.RegistryInfoLookup,
+        private val pending: PendingContent
+    ) : RegistryOps.RegistryInfoLookup {
+        override fun <T> lookup(
+            registryKey: ResourceKey<out Registry<out T>>
+        ): Optional<RegistryOps.RegistryInfo<T>> {
+            val info = delegate.lookup(registryKey)
+
+            if (info.isEmpty) {
+                return info
+            }
+
+            val dir = Registries.elementsDirPath(registryKey)
+            val elements = pending.elementsIn(dir)
+            val tags = pending.tagsIn(dir)
+
+            if (elements.isEmpty() && tags.isEmpty()) {
+                return info
+            }
+
+            return info.map {
+                RegistryOps.RegistryInfo(
+                    it.owner(),
+                    DraftAwareGetter(it.owner(), it.getter(), elements, tags),
+                    it.elementsLifecycle()
+                )
+            }
+        }
+
+        // Present on the interface since 1.21.8 and unchanged at 26.2; nothing about pending
+        // content applies to it, so it delegates untouched.
+        override fun lookupForValueCopyViaBuilders(): HolderLookup.Provider =
+            delegate.lookupForValueCopyViaBuilders()
+    }
+
+    private class DraftAwareGetter<T>(
+        private val owner: HolderOwner<T>,
+        private val live: HolderGetter<T>,
+        private val elements: Set<String>,
+        private val tags: Set<String>
+    ) : HolderGetter<T> {
+        override fun get(key: ResourceKey<T>): Optional<Holder.Reference<T>> {
+            val found = live.get(key)
+
+            if (found.isPresent || idOf(key) !in elements) {
+                return found
+            }
+
+            return Optional.of(Holder.Reference.createStandAlone(owner, key))
+        }
+
+        override fun get(key: TagKey<T>): Optional<HolderSet.Named<T>> {
+            val found = live.get(key)
+
+            if (found.isPresent || idOf(key) !in tags) {
+                return found
+            }
+
+            return Optional.of(HolderSet.emptyNamed(owner, key))
+        }
+    }
+
+    private companion object {
+        /**
+         * The ID part of a `ResourceKey` or `TagKey`, read out of `toString()`.
+         *
+         * Deliberately not `location()`: that accessor returns `ResourceLocation` at 1.21.8 and
+         * `Identifier` at 1.21.11, and it was renamed to `identifier()` along the way, so calling
+         * it would break the one-implementation-serves-all-versions property this class depends on.
+         * `toString()` is declared on classes whose own names never moved.
+         *
+         * `ResourceKey[minecraft:worldgen/biome / ns:key]` and
+         * `TagKey[registry=minecraft:worldgen/biome, location=ns:key]` both end with the ID. If a
+         * future format change breaks the parse, the miss is a no-match, which leaves validation
+         * exactly as strict as it was before this existed.
+         */
+        fun idOf(key: Any): String {
+            val text = key.toString().removeSuffix("]")
+
+            return text.substringAfterLast(" / ")
+                .substringAfterLast('=')
+                .trim()
+        }
+    }
 }

--- a/eco-core/core-nms/v1_21_8/src/main/kotlin/com/willfp/eco/internal/spigot/proxy/v1_21_8/DatapackCodec.kt
+++ b/eco-core/core-nms/v1_21_8/src/main/kotlin/com/willfp/eco/internal/spigot/proxy/v1_21_8/DatapackCodec.kt
@@ -63,11 +63,23 @@ class DatapackCodec : DatapackCodecProxy {
         } catch (e: Throwable) {
             /*
             A placeholder holder for pending content is unbound: a codec that dereferences one
-            during decode, rather than merely resolving it, throws. Falling back to the syntax and
-            path tiers is weaker than a real decode, so it says so out loud rather than reporting a
-            clean pass.
+            during decode, rather than merely resolving it, throws. With nothing pending there is
+            no placeholder to blame, so the throw is the answer and the entry is refused.
+
+            With content pending the entry keeps only its syntax and path checks, because refusing
+            it would fail exactly the publishes this exists to support. That is weaker than a real
+            decode, so it is logged: the alternative is a decode bug that never surfaces.
              */
-            if (pending.isEmpty()) "codec validation threw (${e.message})" else null
+            if (pending.isEmpty()) {
+                "codec validation threw (${e.message})"
+            } else {
+                Bukkit.getLogger().warning(
+                    "[eco] $registryDirPath entry fell back to syntax and path checks only: codec " +
+                        "decode threw while resolving content this publish is writing ($e)"
+                )
+
+                null
+            }
         }
     }
 

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/datapack/DatapackValidator.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/datapack/DatapackValidator.kt
@@ -2,6 +2,7 @@ package com.willfp.eco.internal.spigot.datapack
 
 import com.google.gson.JsonSyntaxException
 import com.willfp.eco.internal.spigot.proxies.DatapackCodecProxy
+import com.willfp.eco.internal.spigot.proxies.PendingContent
 import java.util.logging.Logger
 
 /**
@@ -46,9 +47,11 @@ class DatapackValidator(
     }
 
     /**
+     * @param pending What the same publish is writing, so that a reference to it resolves rather
+     *                than failing as not-yet-live. See [PendingContent].
      * @return null if the entry is valid, else a human-readable error.
      */
-    fun validate(entry: DatapackEntry): String? {
+    fun validate(entry: DatapackEntry, pending: PendingContent = PendingContent.EMPTY): String? {
         validateShape(entry)?.let { return it }
 
         if (!entry.isJson) {
@@ -67,7 +70,7 @@ class DatapackValidator(
             return "$entry: malformed JSON (${e.message})"
         }
 
-        return validateCodec(entry, json)
+        return validateCodec(entry, json, pending)
     }
 
     private fun validateShape(entry: DatapackEntry): String? {
@@ -96,7 +99,7 @@ class DatapackValidator(
         return null
     }
 
-    private fun validateCodec(entry: DatapackEntry, json: String): String? {
+    private fun validateCodec(entry: DatapackEntry, json: String, pending: PendingContent): String? {
         val proxy = codec ?: return null
         val registry = entry.registry.trim('/').lowercase()
 
@@ -104,7 +107,7 @@ class DatapackValidator(
             return null
         }
 
-        val error = runCatching { proxy.validate(registry, json) }
+        val error = runCatching { proxy.validate(registry, json, pending) }
             .getOrElse { return "$entry: codec validation threw (${it.message})" }
             ?: return null
 

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/datapack/EcoDatapackDraft.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/datapack/EcoDatapackDraft.kt
@@ -23,10 +23,22 @@ class DatapackEntry(
     /** Whether this entry's content is JSON, and so subject to canonicalisation and codec checks. */
     val isJson: Boolean = path.endsWith(".json")
 
+    /**
+     * How another entry refers to this one: `namespace:key`, with any known file extension
+     * dropped. A reference names the entry, not the file it happens to live in.
+     */
+    val referenceId: String = "${id.namespace}:${withoutExtension(id.key)}"
+
     override fun toString() = "$registry/${id.namespace}:${id.key}"
 
     companion object {
         private val KNOWN_EXTENSIONS = setOf(".json", ".nbt", ".mcfunction", ".snbt")
+
+        private fun withoutExtension(key: String): String {
+            val extension = KNOWN_EXTENSIONS.firstOrNull { key.endsWith(it) } ?: return key
+
+            return key.removeSuffix(extension)
+        }
 
         private fun fileName(registry: String, id: NamespacedKey, isText: Boolean): String {
             val key = id.key

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/datapack/EcoDatapackHandle.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/datapack/EcoDatapackHandle.kt
@@ -156,7 +156,7 @@ class EcoDatapackHandle(
 
         // Entries in one publish may reference each other, so validation has to know what the
         // whole publish writes before it checks any single entry.
-        val pending = pendingContent(entries)
+        val pending = PendingContent.of(entries)
 
         for (entry in entries) {
             if (!seen.add(entry.path)) {
@@ -168,28 +168,6 @@ class EcoDatapackHandle(
         }
 
         return errors
-    }
-
-    /**
-     * What this publish writes, split into registry elements and tags, keyed by the registry
-     * directory a reference to them would resolve against.
-     */
-    private fun pendingContent(entries: List<DatapackEntry>): PendingContent {
-        val elements = mutableMapOf<String, MutableSet<String>>()
-        val tags = mutableMapOf<String, MutableSet<String>>()
-
-        for (entry in entries) {
-            val registry = entry.registry.trim('/').lowercase()
-            val id = "${entry.id.namespace}:${entry.id.key.removeSuffix(".json")}"
-
-            if (registry.startsWith("tags/")) {
-                tags.getOrPut(registry.removePrefix("tags/")) { mutableSetOf() }.add(id)
-            } else {
-                elements.getOrPut(registry) { mutableSetOf() }.add(id)
-            }
-        }
-
-        return PendingContent(elements, tags)
     }
 
     private fun published(entries: List<DatapackEntry>): InstallResult {

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/datapack/EcoDatapackHandle.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/datapack/EcoDatapackHandle.kt
@@ -3,6 +3,7 @@ package com.willfp.eco.internal.spigot.datapack
 import com.willfp.eco.core.datapack.DatapackDraft
 import com.willfp.eco.core.datapack.DatapackHandle
 import com.willfp.eco.core.datapack.InstallResult
+import com.willfp.eco.internal.spigot.proxies.PendingContent
 import java.io.File
 import java.util.function.Consumer
 import java.util.logging.Logger
@@ -153,16 +154,42 @@ class EcoDatapackHandle(
         val errors = mutableListOf<String>()
         val seen = mutableSetOf<String>()
 
+        // Entries in one publish may reference each other, so validation has to know what the
+        // whole publish writes before it checks any single entry.
+        val pending = pendingContent(entries)
+
         for (entry in entries) {
             if (!seen.add(entry.path)) {
                 errors.add("$entry: duplicate entry, two drafts wrote ${entry.path}")
                 continue
             }
 
-            validator.validate(entry)?.let { errors.add(it) }
+            validator.validate(entry, pending)?.let { errors.add(it) }
         }
 
         return errors
+    }
+
+    /**
+     * What this publish writes, split into registry elements and tags, keyed by the registry
+     * directory a reference to them would resolve against.
+     */
+    private fun pendingContent(entries: List<DatapackEntry>): PendingContent {
+        val elements = mutableMapOf<String, MutableSet<String>>()
+        val tags = mutableMapOf<String, MutableSet<String>>()
+
+        for (entry in entries) {
+            val registry = entry.registry.trim('/').lowercase()
+            val id = "${entry.id.namespace}:${entry.id.key.removeSuffix(".json")}"
+
+            if (registry.startsWith("tags/")) {
+                tags.getOrPut(registry.removePrefix("tags/")) { mutableSetOf() }.add(id)
+            } else {
+                elements.getOrPut(registry) { mutableSetOf() }.add(id)
+            }
+        }
+
+        return PendingContent(elements, tags)
     }
 
     private fun published(entries: List<DatapackEntry>): InstallResult {

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/proxies/DatapackCodecProxy.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/proxies/DatapackCodecProxy.kt
@@ -8,9 +8,11 @@ interface DatapackCodecProxy {
      * values and missing required fields straight through to a server that then refuses to boot.
      *
      * @param registryDirPath The registry directory, e.g. `worldgen/biome`.
+     * @param pending         What the same publish is writing, so that references to it resolve
+     *                        instead of failing as not-yet-live.
      * @return null if valid, else a human-readable error.
      */
-    fun validate(registryDirPath: String, json: String): String?
+    fun validate(registryDirPath: String, json: String, pending: PendingContent): String?
 
     /**
      * Registry directory paths that can be codec-validated on this server.

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/proxies/PendingContent.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/proxies/PendingContent.kt
@@ -1,5 +1,7 @@
 package com.willfp.eco.internal.spigot.proxies
 
+import com.willfp.eco.internal.spigot.datapack.DatapackEntry
+
 /**
  * The entries a publish is about to write, so that codec validation can resolve references to
  * them.
@@ -32,5 +34,28 @@ class PendingContent(
 
     companion object {
         val EMPTY = PendingContent(emptyMap(), emptyMap())
+
+        /**
+         * Splits a draft into the elements and tags it writes.
+         *
+         * One implementation, so that the publish path and the tests agree on what a draft
+         * contributes rather than each deciding for itself.
+         */
+        fun of(entries: Collection<DatapackEntry>): PendingContent {
+            val elements = mutableMapOf<String, MutableSet<String>>()
+            val tags = mutableMapOf<String, MutableSet<String>>()
+
+            for (entry in entries) {
+                val registry = entry.registry.trim('/').lowercase()
+
+                if (registry.startsWith("tags/")) {
+                    tags.getOrPut(registry.removePrefix("tags/")) { mutableSetOf() }.add(entry.referenceId)
+                } else {
+                    elements.getOrPut(registry) { mutableSetOf() }.add(entry.referenceId)
+                }
+            }
+
+            return PendingContent(elements, tags)
+        }
     }
 }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/proxies/PendingContent.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/eco/internal/spigot/proxies/PendingContent.kt
@@ -1,0 +1,36 @@
+package com.willfp.eco.internal.spigot.proxies
+
+/**
+ * The entries a publish is about to write, so that codec validation can resolve references to
+ * them.
+ *
+ * Codec decode resolves some holders eagerly against the live registries — a placed feature's
+ * `feature`, a structure set's `structure`, a structure's `biomes` — and the live registries
+ * cannot contain content this publish has not written yet. Without this, a pack whose entries
+ * reference each other can never be published: the reference resolves only once its target is
+ * live, the target goes live only after a restart, and the restart only follows a successful
+ * write.
+ *
+ * A reference to something in neither the live registries nor the draft still fails, which is the
+ * part worth keeping.
+ *
+ * @param elements Registry directory (`worldgen/biome`) to the IDs the draft writes there.
+ * @param tags     Registry directory the tags apply to, to the tag IDs the draft writes.
+ */
+class PendingContent(
+    val elements: Map<String, Set<String>>,
+    val tags: Map<String, Set<String>>
+) {
+    /** Whether this publish adds nothing that validation needs to know about. */
+    fun isEmpty() = elements.isEmpty() && tags.isEmpty()
+
+    /** The IDs written to [registryDirPath] by this publish. */
+    fun elementsIn(registryDirPath: String): Set<String> = elements[registryDirPath].orEmpty()
+
+    /** The tag IDs written for [registryDirPath] by this publish. */
+    fun tagsIn(registryDirPath: String): Set<String> = tags[registryDirPath].orEmpty()
+
+    companion object {
+        val EMPTY = PendingContent(emptyMap(), emptyMap())
+    }
+}

--- a/eco-core/core-plugin/src/test/kotlin/com/willfp/eco/internal/spigot/datapack/DatapackEntryTests.kt
+++ b/eco-core/core-plugin/src/test/kotlin/com/willfp/eco/internal/spigot/datapack/DatapackEntryTests.kt
@@ -61,4 +61,15 @@ internal class DatapackEntryTests {
 
         Assertions.assertEquals(1, draft.entries.single().content[0])
     }
+
+    @Test
+    fun `the reference id drops a known extension`() {
+        val nbt = DatapackEntry("structure", NamespacedKey("test", "hut.nbt"), byteArrayOf(1), false)
+        val json = DatapackEntry("worldgen/biome", NamespacedKey("test", "grove.json"), "{}".toByteArray(), true)
+        val bare = DatapackEntry("worldgen/biome", NamespacedKey("test", "grove"), "{}".toByteArray(), true)
+
+        Assertions.assertEquals("test:hut", nbt.referenceId)
+        Assertions.assertEquals("test:grove", json.referenceId)
+        Assertions.assertEquals("test:grove", bare.referenceId)
+    }
 }

--- a/eco-core/core-plugin/src/test/kotlin/com/willfp/eco/internal/spigot/datapack/DatapackValidatorTests.kt
+++ b/eco-core/core-plugin/src/test/kotlin/com/willfp/eco/internal/spigot/datapack/DatapackValidatorTests.kt
@@ -1,6 +1,7 @@
 package com.willfp.eco.internal.spigot.datapack
 
 import com.willfp.eco.internal.spigot.proxies.DatapackCodecProxy
+import com.willfp.eco.internal.spigot.proxies.PendingContent
 import org.bukkit.NamespacedKey
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
@@ -9,20 +10,76 @@ internal class DatapackValidatorTests {
     /**
      * Stands in for the server's own codec. Rejects the exact content that killed a live 1.21.11
      * test server: a damage_type with an enum value that does not exist.
+     *
+     * It also models the behaviour that makes [PendingContent] necessary: some reference fields
+     * resolve eagerly during decode, against the live registries plus whatever the same publish is
+     * writing.
      */
     private object FakeCodec : DatapackCodecProxy {
-        override fun validate(registryDirPath: String, json: String): String? =
+        /** What the running server already has, standing in for the live registries. */
+        private val live = setOf("minecraft:flower_plain")
+
+        private val reference = Regex("\"(feature|biomes)\"\\s*:\\s*\"([^\"]+)\"")
+
+        private val targets = mapOf(
+            "feature" to "worldgen/configured_feature",
+            "biomes" to "worldgen/biome"
+        )
+
+        override fun validate(registryDirPath: String, json: String, pending: PendingContent): String? {
             if (json.contains("NOT_A_VALID_SCALING")) {
-                "Unknown element name: NOT_A_VALID_SCALING; No key message_id in MapLike[...]"
-            } else {
-                null
+                return "Unknown element name: NOT_A_VALID_SCALING; No key message_id in MapLike[...]"
             }
 
-        override fun validatableRegistries() = setOf("damage_type", "worldgen/biome")
+            for (match in reference.findAll(json)) {
+                val (field, raw) = match.destructured
+                val target = targets[field] ?: continue
+                val isTag = raw.startsWith("#")
+                val id = raw.removePrefix("#")
+
+                val known = if (isTag) pending.tagsIn(target) else live + pending.elementsIn(target)
+
+                if (id !in known) {
+                    return if (isTag) {
+                        "Missing tag: '$id' in 'minecraft:$target'"
+                    } else {
+                        "Failed to get element ResourceKey[minecraft:$target / $id]"
+                    }
+                }
+            }
+
+            return null
+        }
+
+        override fun validatableRegistries() = setOf(
+            "damage_type",
+            "worldgen/biome",
+            "worldgen/placed_feature",
+            "worldgen/structure"
+        )
     }
 
     private fun entry(registry: String, key: String, content: String, namespace: String = "test") =
         DatapackEntry(registry, NamespacedKey(namespace, key), content.toByteArray(), true)
+
+    /** Mirrors how `EcoDatapackHandle` splits a draft into elements and tags. */
+    private fun pendingFor(entries: List<DatapackEntry>): PendingContent {
+        val elements = mutableMapOf<String, MutableSet<String>>()
+        val tags = mutableMapOf<String, MutableSet<String>>()
+
+        for (entry in entries) {
+            val registry = entry.registry.trim('/').lowercase()
+            val id = "${entry.id.namespace}:${entry.id.key.removeSuffix(".json")}"
+
+            if (registry.startsWith("tags/")) {
+                tags.getOrPut(registry.removePrefix("tags/")) { mutableSetOf() }.add(id)
+            } else {
+                elements.getOrPut(registry) { mutableSetOf() }.add(id)
+            }
+        }
+
+        return PendingContent(elements, tags)
+    }
 
     @Test
     fun `valid content passes`() {
@@ -97,7 +154,9 @@ internal class DatapackValidatorTests {
     @Test
     fun `a throwing proxy fails closed`() {
         val throwing = object : DatapackCodecProxy {
-            override fun validate(registryDirPath: String, json: String): String? = throw IllegalStateException("boom")
+            override fun validate(registryDirPath: String, json: String, pending: PendingContent): String? =
+                throw IllegalStateException("boom")
+
             override fun validatableRegistries() = setOf("damage_type")
         }
 
@@ -110,5 +169,62 @@ internal class DatapackValidatorTests {
         val binary = DatapackEntry("structure", NamespacedKey("test", "a"), byteArrayOf(0x0A, 0x00), false)
 
         Assertions.assertNull(validator.validate(binary))
+    }
+
+    @Test
+    fun `a reference to an entry the same publish writes is accepted`() {
+        val validator = DatapackValidator(FakeCodec)
+
+        val entries = listOf(
+            entry("worldgen/configured_feature", "my_cf", """{"type":"minecraft:flower"}"""),
+            entry("worldgen/placed_feature", "my_pf", """{"feature":"test:my_cf"}""")
+        )
+
+        Assertions.assertNull(validator.validate(entries[1], pendingFor(entries)))
+    }
+
+    @Test
+    fun `a reference to an entry nobody writes is still rejected`() {
+        val validator = DatapackValidator(FakeCodec)
+
+        val entries = listOf(entry("worldgen/placed_feature", "my_pf", """{"feature":"test:absent"}"""))
+        val error = validator.validate(entries[0], pendingFor(entries))
+
+        Assertions.assertNotNull(error)
+        Assertions.assertTrue(error!!.contains("Failed to get element"), error)
+    }
+
+    @Test
+    fun `a tag reference to a tag the same publish writes is accepted`() {
+        val validator = DatapackValidator(FakeCodec)
+
+        val entries = listOf(
+            entry("tags/worldgen/biome", "has_probe", """{"values":["test:my_biome"]}"""),
+            entry("worldgen/structure", "my_structure", """{"biomes":"#test:has_probe"}""")
+        )
+
+        Assertions.assertNull(validator.validate(entries[1], pendingFor(entries)))
+    }
+
+    @Test
+    fun `a tag reference to a tag nobody writes is still rejected`() {
+        val validator = DatapackValidator(FakeCodec)
+
+        val entries = listOf(entry("worldgen/structure", "my_structure", """{"biomes":"#test:absent"}"""))
+        val error = validator.validate(entries[0], pendingFor(entries))
+
+        Assertions.assertNotNull(error)
+        Assertions.assertTrue(error!!.contains("Missing tag"), error)
+    }
+
+    @Test
+    fun `a reference to live content needs no pending set`() {
+        val validator = DatapackValidator(FakeCodec)
+
+        Assertions.assertNull(
+            validator.validate(
+                entry("worldgen/placed_feature", "my_pf", """{"feature":"minecraft:flower_plain"}""")
+            )
+        )
     }
 }

--- a/eco-core/core-plugin/src/test/kotlin/com/willfp/eco/internal/spigot/datapack/DatapackValidatorTests.kt
+++ b/eco-core/core-plugin/src/test/kotlin/com/willfp/eco/internal/spigot/datapack/DatapackValidatorTests.kt
@@ -62,25 +62,6 @@ internal class DatapackValidatorTests {
     private fun entry(registry: String, key: String, content: String, namespace: String = "test") =
         DatapackEntry(registry, NamespacedKey(namespace, key), content.toByteArray(), true)
 
-    /** Mirrors how `EcoDatapackHandle` splits a draft into elements and tags. */
-    private fun pendingFor(entries: List<DatapackEntry>): PendingContent {
-        val elements = mutableMapOf<String, MutableSet<String>>()
-        val tags = mutableMapOf<String, MutableSet<String>>()
-
-        for (entry in entries) {
-            val registry = entry.registry.trim('/').lowercase()
-            val id = "${entry.id.namespace}:${entry.id.key.removeSuffix(".json")}"
-
-            if (registry.startsWith("tags/")) {
-                tags.getOrPut(registry.removePrefix("tags/")) { mutableSetOf() }.add(id)
-            } else {
-                elements.getOrPut(registry) { mutableSetOf() }.add(id)
-            }
-        }
-
-        return PendingContent(elements, tags)
-    }
-
     @Test
     fun `valid content passes`() {
         val validator = DatapackValidator(FakeCodec)
@@ -180,7 +161,7 @@ internal class DatapackValidatorTests {
             entry("worldgen/placed_feature", "my_pf", """{"feature":"test:my_cf"}""")
         )
 
-        Assertions.assertNull(validator.validate(entries[1], pendingFor(entries)))
+        Assertions.assertNull(validator.validate(entries[1], PendingContent.of(entries)))
     }
 
     @Test
@@ -188,7 +169,7 @@ internal class DatapackValidatorTests {
         val validator = DatapackValidator(FakeCodec)
 
         val entries = listOf(entry("worldgen/placed_feature", "my_pf", """{"feature":"test:absent"}"""))
-        val error = validator.validate(entries[0], pendingFor(entries))
+        val error = validator.validate(entries[0], PendingContent.of(entries))
 
         Assertions.assertNotNull(error)
         Assertions.assertTrue(error!!.contains("Failed to get element"), error)
@@ -203,7 +184,7 @@ internal class DatapackValidatorTests {
             entry("worldgen/structure", "my_structure", """{"biomes":"#test:has_probe"}""")
         )
 
-        Assertions.assertNull(validator.validate(entries[1], pendingFor(entries)))
+        Assertions.assertNull(validator.validate(entries[1], PendingContent.of(entries)))
     }
 
     @Test
@@ -211,10 +192,23 @@ internal class DatapackValidatorTests {
         val validator = DatapackValidator(FakeCodec)
 
         val entries = listOf(entry("worldgen/structure", "my_structure", """{"biomes":"#test:absent"}"""))
-        val error = validator.validate(entries[0], pendingFor(entries))
+        val error = validator.validate(entries[0], PendingContent.of(entries))
 
         Assertions.assertNotNull(error)
         Assertions.assertTrue(error!!.contains("Missing tag"), error)
+    }
+
+    @Test
+    fun `an entry written as a file still contributes the bare id`() {
+        val entries = listOf(
+            entry("worldgen/configured_feature", "my_cf.json", """{"type":"minecraft:flower"}"""),
+            entry("worldgen/structure", "my_structure.nbt", "not json")
+        )
+
+        val pending = PendingContent.of(entries)
+
+        Assertions.assertEquals(setOf("test:my_cf"), pending.elementsIn("worldgen/configured_feature"))
+        Assertions.assertEquals(setOf("test:my_structure"), pending.elementsIn("worldgen/structure"))
     }
 
     @Test


### PR DESCRIPTION
## The problem

Tier-3 validation decodes each datapack entry through the server's own codec. Some codecs resolve referenced holders **eagerly, against the live registries** — a placed feature's `feature`, a structure set's `structure`, a structure's `biomes` — and the live registries cannot contain content the same publish is writing.

That makes any pack whose entries reference each other unpublishable: the reference validates only once its target is live, the target goes live only after a restart, and the restart only follows a successful write. The same publish succeeds on the *next* boot, which proves it is the liveness check and nothing else.

Measured on a live Paper 26.2 server against stock eco:

```
apply(placed_feature -> own configured_feature)  -> FAILED  Failed to get element ResourceKey[… / cfeco:probe_cf]
apply(structure_set  -> own structure)           -> FAILED  Failed to get element ResourceKey[… / cfeco:probe_structure]
register(structure biomes -> own biome, by ID)   -> FAILED  Failed to get element cfstruct:probe_biome
register(structure biomes -> own biome, by tag)  -> FAILED  Missing tag: 'cfstruct:has_probe' in 'minecraft:worldgen/biome'
apply(biome -> own placed_feature)               -> RESTART_REQUIRED   (that field is lazy, so it was always fine)
```

After this change, all of the above return `RESTART_REQUIRED`, and on the next boot the content resolves from the registry, generates, and is findable through `locateNearestStructure`.

## The fix

Validation now decodes against the live registries **plus the publish's own draft**.

- **`PendingContent`** (new) — what a publish is about to write, split into registry elements and tags, keyed by the registry directory a reference resolves against.
- **`DatapackCodecProxy.validate`** takes it, **`EcoDatapackHandle`** builds it once per publish from the draft, **`DatapackValidator`** threads it through. Tiers 1 and 2 (shape/path and JSON syntax) are untouched.
- **`DatapackCodec`** (NMS, implemented in `v1_21_8` and inherited by every later module) wraps `RegistryOps.RegistryInfoLookup` so a lookup miss the draft covers resolves to `Holder.Reference.createStandAlone`, or `HolderSet.emptyNamed` for a tag.

## Validation is not weakened

Only "this ID is not live yet" stops being fatal. A reference to something in **neither** the live registries **nor** the draft still fails, and every other codec check — type errors, unknown enum values, missing required fields, malformed JSON — is unchanged and still fails with the same messages as before.

Two details worth noting for review:

1. The NMS side reads IDs from `ResourceKey.toString()` / `TagKey.toString()` rather than calling `location()`. That accessor returns `ResourceLocation` at 1.21.8 and was renamed to `identifier()` returning `Identifier` at 1.21.11, so calling it would break the one-implementation-serves-all-versions property the class depends on. If the `toString` format ever changes, the parse simply misses and validation is exactly as strict as it was before.
2. A placeholder holder is unbound, so a codec that *dereferences* one during decode would throw. That case is caught and falls back to the syntax and path tiers rather than propagating.

## Testing

- Four new `DatapackValidatorTests` cases: a reference to an entry the same publish writes is accepted; a reference to an entry nobody writes is still rejected; the same pair for tags. Existing cases pass unchanged.
- Live-server probe on Paper 26.2: a publish of a biome, a structure naming that biome, and a structure set naming that structure returns `RESTART_REQUIRED`, and the structure resolves, generates, and is locatable on the next boot.
