### PR TITLE
fix: version qualifier mismatch

### DIFF
--- a/eco-api/src/main/java/com/willfp/eco/core/EcoPlugin.java
+++ b/eco-api/src/main/java/com/willfp/eco/core/EcoPlugin.java
@@ -406,7 +406,7 @@ public abstract class EcoPlugin extends JavaPlugin implements PluginLike, Regist
             requiredVersion = this.getProps().getEcoApiVersion();
         }
 
-        if (!(runningVersion.compareTo(requiredVersion) > 0 || runningVersion.equals(requiredVersion))) {
+        if (!runningVersion.isAtLeast(requiredVersion)) {
             this.getLogger().severe("You are running an outdated version of eco!");
             this.getLogger().severe("You must be on at least " + requiredVersion);
             this.getLogger().severe("Download the newest version here:");

--- a/eco-api/src/main/java/com/willfp/eco/core/version/Version.java
+++ b/eco-api/src/main/java/com/willfp/eco/core/version/Version.java
@@ -68,6 +68,27 @@ public class Version implements Comparable<Version> {
         return thisHasQual ? -1 : 1;
     }
 
+    /**
+     * Whether this version satisfies a minimum required version, ignoring qualifiers.
+     * <p>
+     * Qualifiers are build tags rather than versions behind, so {@code 2026.34-local} and
+     * {@code 2026.34-SNAPSHOT} both satisfy a requirement of {@code 2026.34}.
+     *
+     * @param required The minimum required version.
+     * @return True if this version is at least the required version.
+     */
+    public boolean isAtLeast(@NotNull final Version required) {
+        int maxLen = Math.max(this.parts.length, required.parts.length);
+        for (int i = 0; i < maxLen; i++) {
+            int a = i < this.parts.length ? this.parts[i] : 0;
+            int b = i < required.parts.length ? required.parts[i] : 0;
+            if (a != b) {
+                return a > b;
+            }
+        }
+        return true;
+    }
+
     @Override
     public String toString() {
         return raw;

--- a/eco-api/src/test/kotlin/com/willfp/eco/core/version/VersionTests.kt
+++ b/eco-api/src/test/kotlin/com/willfp/eco/core/version/VersionTests.kt
@@ -1,0 +1,59 @@
+package com.willfp.eco.core.version
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for [Version.isAtLeast].
+ *
+ * Qualifiers are build tags rather than versions behind, so they are ignored when checking
+ * against a minimum required version, unlike in [Version.compareTo] where a qualified version
+ * sorts below the same version without one.
+ */
+class VersionTests {
+    @Test
+    fun `equal versions satisfy the requirement`() {
+        assertTrue(Version("2026.34").isAtLeast(Version("2026.34")))
+    }
+
+    @Test
+    fun `newer versions satisfy the requirement`() {
+        assertTrue(Version("2026.35").isAtLeast(Version("2026.34")))
+        assertTrue(Version("2027.1").isAtLeast(Version("2026.34")))
+    }
+
+    @Test
+    fun `older versions do not satisfy the requirement`() {
+        assertFalse(Version("2026.33").isAtLeast(Version("2026.34")))
+        assertFalse(Version("2025.99").isAtLeast(Version("2026.34")))
+    }
+
+    @Test
+    fun `qualified versions satisfy a requirement of the same version`() {
+        assertTrue(Version("2026.34-local").isAtLeast(Version("2026.34")))
+        assertTrue(Version("2026.34-SNAPSHOT").isAtLeast(Version("2026.34")))
+    }
+
+    @Test
+    fun `qualified versions do not satisfy a requirement of a newer version`() {
+        assertFalse(Version("2026.34-local").isAtLeast(Version("2026.35")))
+    }
+
+    @Test
+    fun `a qualified requirement is satisfied by the plain version`() {
+        assertTrue(Version("2026.34").isAtLeast(Version("2026.34-SNAPSHOT")))
+    }
+
+    @Test
+    fun `missing segments are treated as zero`() {
+        assertTrue(Version("1.0").isAtLeast(Version("1.0.0")))
+        assertTrue(Version("1.0.0").isAtLeast(Version("1.0")))
+        assertFalse(Version("1.0").isAtLeast(Version("1.0.1")))
+    }
+
+    @Test
+    fun `comparison ordering still ranks qualifiers below plain versions`() {
+        assertTrue(Version("2026.34-local") < Version("2026.34"))
+    }
+}


### PR DESCRIPTION
A build of eco tagged with a qualifier — `2026.34-local`, `2026.34-SNAPSHOT` — failed the minimum eco version check against a requirement of `2026.34`, so every dependent plugin was registered as outdated and the server shut down:

```
Caused by: com.willfp.eco.core.version.OutdatedEcoVersionError: This plugin requires at least eco version 2026.34 to run.
    at eco-2026.34-local-all.jar//com.willfp.eco.core.EcoPlugin.<init>(EcoPlugin.java:423)
```

The check used `Version.compareTo`, which ranks a qualified version below the same version without one (`1.0 > 1.0-SNAPSHOT`). That ordering is right for the update checker but wrong for a minimum-version requirement: a qualifier is a build tag, not a version behind.

The check now uses a new `Version.isAtLeast`, which compares numeric segments only. `compareTo` and `equals` are untouched, so update-checker sorting is unchanged.

Covered by `VersionTests`.
